### PR TITLE
Add SEO meta description + page title generator (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 vendor/
+.Build/
+composer.lock
 .phpunit.cache/
 .idea/
 .vscode/

--- a/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
+++ b/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Controller\Ajax;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\MetaDescriptionService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Backend AJAX endpoint for the "Generate meta description" wizard.
+ *
+ * Route: GET/POST /typo3/ajax/ai-editorial-helper/meta?pageUid=123
+ * Requires a valid backend user session (TYPO3 dispatches AJAX routes through
+ * the backend authentication middleware).
+ */
+final class MetaDescriptionAjaxController
+{
+    public function __construct(
+        private readonly MetaDescriptionService $service,
+        private readonly ConnectionPool $connectionPool,
+    ) {
+    }
+
+    public function generate(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getParsedBody() + $request->getQueryParams();
+        $pageUid = (int)($params['pageUid'] ?? 0);
+
+        if ($pageUid <= 0) {
+            return $this->error('Missing or invalid pageUid parameter.', 400);
+        }
+
+        $page = BackendUtility::getRecord('pages', $pageUid);
+        if (!is_array($page)) {
+            return $this->error(sprintf('Page %d not found.', $pageUid), 404);
+        }
+
+        $title = (string)($page['title'] ?? '');
+        $body = $this->loadPageBody($pageUid);
+
+        try {
+            $result = $this->service->generate($title, $body);
+        } catch (LmStudioException $e) {
+            return $this->error($this->humanizeException($e), 502);
+        }
+
+        return new JsonResponse([
+            'success' => true,
+            'metaDescription' => $result['metaDescription'],
+            'seoTitle' => $result['seoTitle'],
+        ]);
+    }
+
+    /**
+     * Concatenate visible text from the page's tt_content elements (default
+     * language only — translation handling is out of scope for #1).
+     */
+    private function loadPageBody(int $pageUid): string
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $rows = $qb
+            ->select('header', 'subheader', 'bodytext')
+            ->from('tt_content')
+            ->where(
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $parts = [];
+        foreach ($rows as $row) {
+            foreach (['header', 'subheader', 'bodytext'] as $field) {
+                $value = trim((string)($row[$field] ?? ''));
+                if ($value !== '') {
+                    $parts[] = $value;
+                }
+            }
+        }
+        return implode("\n\n", $parts);
+    }
+
+    private function humanizeException(LmStudioException $e): string
+    {
+        return match ($e->getCode()) {
+            LmStudioException::CODE_UNREACHABLE
+                => 'LM Studio is not reachable. Start LM Studio and load the configured model, then retry.',
+            LmStudioException::CODE_NO_MODEL_LOADED
+                => 'No model is loaded in LM Studio. Load the configured model in the LM Studio UI and retry.',
+            LmStudioException::CODE_INVALID_RESPONSE
+                => 'The model returned an unexpected response. Try again, or switch to a more capable model.',
+            default => 'LM Studio request failed: ' . $e->getMessage(),
+        };
+    }
+
+    private function error(string $message, int $status): ResponseInterface
+    {
+        return new JsonResponse(
+            ['success' => false, 'error' => $message],
+            $status,
+        );
+    }
+}

--- a/Classes/Exception/LmStudioException.php
+++ b/Classes/Exception/LmStudioException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Exception;
+
+class LmStudioException extends \RuntimeException
+{
+    public const CODE_UNREACHABLE = 1714140001;
+    public const CODE_NO_MODEL_LOADED = 1714140002;
+    public const CODE_INVALID_RESPONSE = 1714140003;
+    public const CODE_HTTP_ERROR = 1714140004;
+}

--- a/Classes/Form/FieldWizard/GenerateMetaDescriptionWizard.php
+++ b/Classes/Form/FieldWizard/GenerateMetaDescriptionWizard.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Form\FieldWizard;
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
+
+/**
+ * Renders a "Generate with AI" button next to the meta description / SEO title
+ * fields on the pages-edit form.
+ *
+ * The actual wiring lives in {@see \Kairos\AiEditorialHelper\Configuration\TCA\Overrides\pages}
+ * — this wizard just emits the markup + ES module instruction. The button
+ * itself is wired to the AJAX route in the loaded JS module.
+ */
+final class GenerateMetaDescriptionWizard extends AbstractNode
+{
+    public function render(): array
+    {
+        $row = $this->data['databaseRow'] ?? [];
+        $pageUid = (int)($row['uid'] ?? 0);
+        $fieldName = (string)($this->data['fieldName'] ?? '');
+
+        // Only show the button when editing an existing page (we need a UID to
+        // load the body content from tt_content). For new (uid<=0) records the
+        // wizard hides itself.
+        if ($pageUid <= 0) {
+            return [
+                'iconIdentifier' => null,
+                'html' => '',
+                'javaScriptModules' => [],
+            ];
+        }
+
+        $buttonId = 'ai-editorial-helper-meta-' . $pageUid . '-' . htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8');
+
+        $html = sprintf(
+            '<div class="form-wizards-element">'
+            . '<button type="button" class="btn btn-default ai-editorial-helper-generate" '
+            . 'id="%s" data-page-uid="%d" data-field="%s">'
+            . '<span class="t3js-icon icon icon-size-small">✨</span> %s'
+            . '</button>'
+            . '</div>',
+            $buttonId,
+            $pageUid,
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($this->translate('wizard.generate'), ENT_QUOTES, 'UTF-8'),
+        );
+
+        return [
+            'iconIdentifier' => null,
+            'html' => $html,
+            'javaScriptModules' => [
+                JavaScriptModuleInstruction::create('@kairos/ai-editorial-helper/meta-description-wizard.js'),
+            ],
+            'stylesheetFiles' => [],
+            'requireJsModules' => [],
+            'additionalHiddenFields' => [],
+            'additionalInlineLanguageLabelFiles' => [],
+            'inlineData' => [],
+        ];
+    }
+
+    private function translate(string $key): string
+    {
+        $lang = $GLOBALS['LANG'] ?? null;
+        if ($lang !== null && method_exists($lang, 'sL')) {
+            $label = $lang->sL('LLL:EXT:ai_editorial_helper/Resources/Private/Language/locallang_be.xlf:' . $key);
+            if (is_string($label) && $label !== '') {
+                return $label;
+            }
+        }
+        return 'Generate with AI';
+    }
+}

--- a/Classes/Service/ExtensionSettings.php
+++ b/Classes/Service/ExtensionSettings.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Strongly-typed accessor for ai_editorial_helper ext_conf_template settings.
+ *
+ * Reads once from ExtensionConfiguration and exposes typed getters.
+ * Falls back to documented defaults on any read failure so the extension never
+ * blows up on a missing/empty install setting.
+ */
+class ExtensionSettings implements SingletonInterface
+{
+    public const EXT_KEY = 'ai_editorial_helper';
+
+    public const DEFAULT_ENDPOINT = 'http://localhost:1234/v1';
+    public const DEFAULT_MODEL = 'qwen/qwen3-14b';
+    public const DEFAULT_TIMEOUT = 60;
+
+    private string $endpoint;
+    private string $model;
+    private int $timeout;
+    private string $apiKey;
+
+    public function __construct(ExtensionConfiguration $configuration)
+    {
+        $raw = [];
+        try {
+            $raw = (array)$configuration->get(self::EXT_KEY);
+        } catch (\Throwable) {
+            // Fall through to defaults — extension may not be fully installed yet.
+        }
+
+        $this->endpoint = self::trimOrDefault($raw['endpoint'] ?? null, self::DEFAULT_ENDPOINT);
+        $this->model = self::trimOrDefault($raw['model'] ?? null, self::DEFAULT_MODEL);
+        $this->timeout = self::positiveIntOrDefault($raw['timeout'] ?? null, self::DEFAULT_TIMEOUT);
+        $this->apiKey = trim((string)($raw['apiKey'] ?? ''));
+    }
+
+    public function getEndpoint(): string
+    {
+        return rtrim($this->endpoint, '/');
+    }
+
+    public function getModel(): string
+    {
+        return $this->model;
+    }
+
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->apiKey;
+    }
+
+    public function hasApiKey(): bool
+    {
+        return $this->apiKey !== '';
+    }
+
+    private static function trimOrDefault(mixed $value, string $default): string
+    {
+        $candidate = trim((string)($value ?? ''));
+        return $candidate !== '' ? $candidate : $default;
+    }
+
+    private static function positiveIntOrDefault(mixed $value, int $default): int
+    {
+        if ($value === null || $value === '') {
+            return $default;
+        }
+        $int = (int)$value;
+        return $int > 0 ? $int : $default;
+    }
+}

--- a/Classes/Service/LmStudioClient.php
+++ b/Classes/Service/LmStudioClient.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Psr\Http\Message\ResponseInterface;
+use TYPO3\CMS\Core\Http\RequestFactory;
+
+/**
+ * Thin HTTP client for LM Studio's OpenAI-compatible API.
+ *
+ * Shared by all editorial helper services (#1-#6). Speaks `/v1/chat/completions`
+ * and `/v1/models`. No streaming, no function-calling — kept deliberately small.
+ *
+ * All errors surface as {@see LmStudioException} with a typed code so callers
+ * can render a human-friendly backend message.
+ */
+class LmStudioClient
+{
+    public function __construct(
+        private readonly RequestFactory $requestFactory,
+        private readonly ExtensionSettings $settings,
+    ) {
+    }
+
+    /**
+     * Send a chat completion request and return the assistant's text content.
+     *
+     * @param array<int, array{role: string, content: string}> $messages
+     * @param array<string, mixed> $options Extra fields merged into the request body
+     *                                      (e.g. ['temperature' => 0.2, 'max_tokens' => 256]).
+     */
+    public function chat(array $messages, array $options = []): string
+    {
+        $body = array_merge(
+            ['model' => $this->settings->getModel(), 'messages' => $messages],
+            $options,
+        );
+
+        $response = $this->postJson('/chat/completions', $body);
+        $payload = $this->decodeJson($response);
+
+        $content = $payload['choices'][0]['message']['content'] ?? null;
+        if (!is_string($content)) {
+            throw new LmStudioException(
+                'LM Studio response missing choices[0].message.content',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+        return trim($content);
+    }
+
+    /**
+     * Send a chat completion that must conform to a JSON Schema.
+     *
+     * LM Studio uses `response_format: { type: "json_schema", json_schema: {...} }`
+     * (NOT OpenAI's older `json_object` shorthand — that returns a 400 error on
+     * LM Studio). Grammar-constrained sampling enforces the schema during
+     * generation, so the returned string is guaranteed to parse.
+     *
+     * @param array<int, array{role: string, content: string}> $messages
+     * @param string $schemaName  Identifier passed to LM Studio (alphanumeric/underscore).
+     * @param array<string, mixed> $schema       JSON Schema describing the expected object.
+     * @param array<string, mixed> $options      Extra fields merged into the request body.
+     * @return array<mixed>
+     */
+    public function chatJsonSchema(array $messages, string $schemaName, array $schema, array $options = []): array
+    {
+        $merged = $options;
+        $merged['response_format'] = [
+            'type' => 'json_schema',
+            'json_schema' => [
+                'name' => $schemaName,
+                'strict' => true,
+                'schema' => $schema,
+            ],
+        ];
+        $raw = $this->chat($messages, $merged);
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            throw new LmStudioException(
+                'LM Studio returned non-JSON content despite a json_schema response_format',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+        return $decoded;
+    }
+
+    /**
+     * Check whether the configured endpoint responds and at least one model is loaded.
+     * Returns false on any failure (connection refused, timeout, empty model list).
+     */
+    public function isAvailable(): bool
+    {
+        try {
+            $response = $this->getJson('/models');
+            $payload = $this->decodeJson($response);
+            $models = $payload['data'] ?? [];
+            return is_array($models) && $models !== [];
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function listModels(): array
+    {
+        $response = $this->getJson('/models');
+        $payload = $this->decodeJson($response);
+        $models = $payload['data'] ?? [];
+        if (!is_array($models)) {
+            return [];
+        }
+        $ids = [];
+        foreach ($models as $model) {
+            if (is_array($model) && isset($model['id']) && is_string($model['id'])) {
+                $ids[] = $model['id'];
+            }
+        }
+        return $ids;
+    }
+
+    private function postJson(string $path, array $body): ResponseInterface
+    {
+        return $this->request('POST', $path, [
+            'json' => $body,
+            'headers' => $this->buildHeaders(),
+            'timeout' => $this->settings->getTimeout(),
+            'http_errors' => false,
+        ]);
+    }
+
+    private function getJson(string $path): ResponseInterface
+    {
+        return $this->request('GET', $path, [
+            'headers' => $this->buildHeaders(),
+            'timeout' => $this->settings->getTimeout(),
+            'http_errors' => false,
+        ]);
+    }
+
+    private function request(string $method, string $path, array $options): ResponseInterface
+    {
+        $uri = $this->settings->getEndpoint() . '/' . ltrim($path, '/');
+        try {
+            return $this->requestFactory->request($uri, $method, $options);
+        } catch (\Throwable $e) {
+            throw new LmStudioException(
+                sprintf('Cannot reach LM Studio at %s: %s', $uri, $e->getMessage()),
+                LmStudioException::CODE_UNREACHABLE,
+                $e,
+            );
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildHeaders(): array
+    {
+        $headers = [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ];
+        if ($this->settings->hasApiKey()) {
+            $headers['Authorization'] = 'Bearer ' . $this->settings->getApiKey();
+        }
+        return $headers;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function decodeJson(ResponseInterface $response): array
+    {
+        $status = $response->getStatusCode();
+        $raw = (string)$response->getBody();
+
+        if ($status >= 400) {
+            $message = $this->extractErrorMessage($raw) ?? sprintf('HTTP %d from LM Studio', $status);
+            $code = $this->classifyError($status, $message);
+            throw new LmStudioException($message, $code);
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            throw new LmStudioException(
+                'LM Studio returned a non-JSON response body',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+        return $decoded;
+    }
+
+    private function extractErrorMessage(string $raw): ?string
+    {
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+        // OpenAI shape: {"error": {"message": "..."}}; LM Studio also returns plain {"error": "..."}
+        $err = $decoded['error'] ?? null;
+        if (is_array($err) && isset($err['message']) && is_string($err['message'])) {
+            return $err['message'];
+        }
+        if (is_string($err)) {
+            return $err;
+        }
+        return null;
+    }
+
+    private function classifyError(int $status, string $message): int
+    {
+        $lower = strtolower($message);
+        if (
+            $status === 404
+            || str_contains($lower, 'no model')
+            || str_contains($lower, 'model not found')
+            || str_contains($lower, 'no models loaded')
+        ) {
+            return LmStudioException::CODE_NO_MODEL_LOADED;
+        }
+        return LmStudioException::CODE_HTTP_ERROR;
+    }
+}

--- a/Classes/Service/MetaDescriptionService.php
+++ b/Classes/Service/MetaDescriptionService.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+
+/**
+ * Generates an SEO meta description and title for a TYPO3 page.
+ *
+ * Caps:
+ *   - meta description ≤ 160 chars
+ *   - SEO title       ≤ 60 chars
+ *
+ * Both caps are enforced via the prompt AND a hard post-trim, because LLMs
+ * routinely overshoot length constraints. Trim is sentence-aware where
+ * possible so we don't cut off mid-word.
+ */
+class MetaDescriptionService
+{
+    public const META_DESCRIPTION_MAX = 160;
+    public const SEO_TITLE_MAX = 60;
+
+    /**
+     * Schema cap is set BELOW the public cap so grammar-constrained sampling
+     * still leaves room for {@see trimToLength()} to back off to a word boundary
+     * when the LLM happens to land mid-word at the schema limit.
+     */
+    private const SCHEMA_META_MAX = 155;
+    private const SCHEMA_TITLE_MAX = 55;
+
+    private const SYSTEM_PROMPT = <<<TXT
+You are an SEO copywriter assisting an editor in a TYPO3 CMS.
+Given a page's title and body content, return a JSON object with two fields:
+  - "metaDescription": a single-sentence search-result snippet, max 155 characters.
+  - "seoTitle":        a concise click-worthy page title, max 55 characters.
+
+Rules:
+  - Match the language of the source content (German source → German output, English source → English output).
+  - Stay safely under the character caps. End on a complete word, not mid-syllable.
+  - No trailing ellipsis. End on punctuation or a complete word.
+  - Do not include the site name, brand, or any boilerplate suffix — the editor adds those.
+  - Do not invent facts that are absent from the source.
+TXT;
+
+    public function __construct(
+        private readonly LmStudioClient $client,
+    ) {
+    }
+
+    /**
+     * @param string $title       Existing page title (may be empty).
+     * @param string $body        Plain-text body content (HTML will be stripped).
+     * @return array{metaDescription: string, seoTitle: string}
+     *
+     * @throws LmStudioException When the LLM is unreachable or returns garbage.
+     */
+    public function generate(string $title, string $body): array
+    {
+        $cleanBody = $this->extractText($body);
+        if ($cleanBody === '' && trim($title) === '') {
+            throw new LmStudioException(
+                'Cannot generate meta description: page has no title and no content.',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        $userMessage = sprintf(
+            "PAGE TITLE:\n%s\n\nPAGE CONTENT:\n%s",
+            trim($title) !== '' ? trim($title) : '(no title)',
+            $cleanBody !== '' ? $cleanBody : '(no body content)',
+        );
+
+        $payload = $this->client->chatJsonSchema(
+            [
+                ['role' => 'system', 'content' => self::SYSTEM_PROMPT],
+                ['role' => 'user', 'content' => $userMessage],
+            ],
+            'AiEditorialMetaResult',
+            [
+                'type' => 'object',
+                'properties' => [
+                    'metaDescription' => ['type' => 'string', 'maxLength' => self::SCHEMA_META_MAX],
+                    'seoTitle' => ['type' => 'string', 'maxLength' => self::SCHEMA_TITLE_MAX],
+                ],
+                'required' => ['metaDescription', 'seoTitle'],
+                'additionalProperties' => false,
+            ],
+            ['temperature' => 0.3],
+        );
+
+        $meta = $this->trimToLength((string)($payload['metaDescription'] ?? ''), self::META_DESCRIPTION_MAX);
+        $seo = $this->trimToLength((string)($payload['seoTitle'] ?? ''), self::SEO_TITLE_MAX);
+
+        if ($meta === '' || $seo === '') {
+            throw new LmStudioException(
+                'LM Studio returned an empty metaDescription or seoTitle.',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        return ['metaDescription' => $meta, 'seoTitle' => $seo];
+    }
+
+    /**
+     * Strip HTML tags, decode entities, collapse whitespace, cap length so the
+     * prompt stays within reasonable token budget for small local models.
+     */
+    private function extractText(string $body): string
+    {
+        $stripped = strip_tags($body);
+        $decoded = html_entity_decode($stripped, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $collapsed = preg_replace('/\s+/u', ' ', $decoded) ?? '';
+        $trimmed = trim($collapsed);
+        // 8000 chars ≈ ~2k tokens — generous for a meta description prompt.
+        if (mb_strlen($trimmed) > 8000) {
+            $trimmed = mb_substr($trimmed, 0, 8000);
+        }
+        return $trimmed;
+    }
+
+    /**
+     * Enforce a hard cap and clean up the trailing edge.
+     *
+     * Two correction passes:
+     *   1. If the value exceeds the cap, hard-cut at the cap.
+     *   2. If the value ends mid-word (last char is a letter/digit AND the
+     *      length is close to the cap), back off to the previous space.
+     *      This handles the case where the LLM's schema-limited output stopped
+     *      mid-syllable — the cap was reached during sampling, not after.
+     *
+     * Also strips dangling punctuation that should never end an SEO snippet.
+     */
+    private function trimToLength(string $value, int $max): string
+    {
+        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? '');
+        if ($value === '') {
+            return '';
+        }
+
+        if (mb_strlen($value) > $max) {
+            $value = mb_substr($value, 0, $max);
+        }
+
+        $lastChar = mb_substr($value, -1);
+        $endsMidWord = preg_match('/[\p{L}\p{N}]/u', $lastChar) === 1;
+        $isNearCap = mb_strlen($value) >= max($max - 5, (int)($max * 0.85));
+
+        if ($endsMidWord && $isNearCap) {
+            $lastSpace = mb_strrpos($value, ' ');
+            if ($lastSpace !== false && $lastSpace >= (int)($max * 0.6)) {
+                $value = mb_substr($value, 0, $lastSpace);
+            }
+        }
+
+        return rtrim($value, " \t\n\r\0\x0B,;:|-—–");
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Kairos\AiEditorialHelper\Controller\Ajax\MetaDescriptionAjaxController;
+
+return [
+    'ai_editorial_helper_meta' => [
+        'path' => '/ai-editorial-helper/meta',
+        'target' => MetaDescriptionAjaxController::class . '::generate',
+    ],
+];

--- a/Configuration/JavaScriptModules.php
+++ b/Configuration/JavaScriptModules.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'dependencies' => ['backend', 'core'],
+    'imports' => [
+        '@kairos/ai-editorial-helper/' => 'EXT:ai_editorial_helper/Resources/Public/JavaScript/',
+    ],
+];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,3 +6,14 @@ services:
 
   Kairos\AiEditorialHelper\:
     resource: '../Classes/*'
+
+  # AJAX controllers must be fetchable from the container at request time.
+  Kairos\AiEditorialHelper\Controller\Ajax\:
+    resource: '../Classes/Controller/Ajax/*'
+    public: true
+
+  # Form node registry instantiates field wizards via GeneralUtility::makeInstance,
+  # which uses the container only for public services in v13.
+  Kairos\AiEditorialHelper\Form\FieldWizard\:
+    resource: '../Classes/Form/FieldWizard/*'
+    public: true

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+defined('TYPO3') or die();
+
+use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
+
+(static function (): void {
+    if (!isset($GLOBALS['TCA']['pages']['columns'])) {
+        return;
+    }
+
+    $columns = &$GLOBALS['TCA']['pages']['columns'];
+
+    $wizardConfig = [
+        'aiEditorialHelperGenerate' => [
+            'renderType' => 'aiEditorialHelperGenerateMeta',
+        ],
+    ];
+
+    foreach (['description', 'seo_title'] as $field) {
+        if (!isset($columns[$field]['config'])) {
+            continue;
+        }
+        $columns[$field]['config']['fieldWizard'] = array_merge(
+            $columns[$field]['config']['fieldWizard'] ?? [],
+            $wizardConfig,
+        );
+    }
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140100] = [
+        'nodeName' => 'aiEditorialHelperGenerateMeta',
+        'priority' => 40,
+        'class' => GenerateMetaDescriptionWizard::class,
+    ];
+})();

--- a/README.md
+++ b/README.md
@@ -2,22 +2,85 @@
 
 Local-LLM-powered editorial assistant for TYPO3 v13. Generates SEO metadata,
 tags, teasers, slugs, DE↔EN translation stubs, and content quality flags using
-LM Studio on the local machine. No data leaves the server.
+LM Studio on the local machine. **No data leaves the server.**
 
 Built autonomously by [kairos](https://backant.io).
 
-## Features (planned)
+## Status
 
-- SEO meta description + page title generator
-- Auto-tag / category suggester
-- Teaser / excerpt generator
-- URL slug suggester
-- DE↔EN translation stub
-- Content quality flags (sentence length, missing headings, tone)
+| Feature | Status |
+|---|---|
+| SEO meta description + page title (#1) | ✅ Shipped — first release |
+| Auto-tag / category suggester (#2) | ⏳ Planned |
+| Teaser / excerpt generator (#3) | ⏳ Planned |
+| URL slug suggester (#4) | ⏳ Planned |
+| DE↔EN translation stub (#5) | ⏳ Planned |
+| Content quality flags (#6) | ⏳ Planned |
 
-## Runtime
+## Runtime requirements
 
+- TYPO3 v13.0+
+- PHP 8.2+
 - [LM Studio](https://lmstudio.ai/) running locally with the local server enabled
-- Default model: `qwen/qwen3-14b` (Qwen 3 14B Instruct via LM Studio)
-- Endpoint: `http://localhost:1234/v1` (OpenAI-compatible API, configurable per extension setting)
-- Load the model into LM Studio's UI before using the extension; the extension surfaces a clear backend message if no model is loaded.
+- A loaded model — default: `qwen/qwen3-14b` (Qwen 3 14B Instruct).
+  Other tested models: `mistralai/magistral-small-2509`.
+
+LM Studio exposes an **OpenAI-compatible API** at `http://localhost:1234/v1`.
+The extension uses LM Studio's `response_format: { type: "json_schema" }`
+mode for structured output, which is grammar-constrained for guaranteed
+parseable JSON.
+
+## Installation
+
+```bash
+composer require kairos/typo3-ai-helper:dev-main
+vendor/bin/typo3 extension:setup
+```
+
+## Configuration
+
+In the TYPO3 install tool → **Settings → Extension Configuration → ai_editorial_helper**:
+
+| Setting | Default | Description |
+|---|---|---|
+| `endpoint` | `http://localhost:1234/v1` | OpenAI-compatible base URL exposed by LM Studio |
+| `model` | `qwen/qwen3-14b` | Model identifier as listed by `/v1/models` |
+| `timeout` | `60` | Request timeout in seconds |
+| `apiKey` | `` (empty) | Optional bearer token; LM Studio doesn't need one for local use |
+
+## Usage — SEO meta description + page title
+
+1. Edit a page in the TYPO3 backend.
+2. Open the **SEO** tab.
+3. Click **Generate with AI** next to the *Description* or *SEO Title* field.
+4. The extension reads the page's title and tt_content (default language) and
+   asks LM Studio for a meta description (≤160 chars) and SEO title (≤60 chars).
+5. Both values are inserted into the form. Review, edit, save.
+
+Errors (LM Studio not running, no model loaded) are surfaced as backend
+notifications, not stack traces.
+
+## Development
+
+```bash
+composer install
+docker run --rm -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit -c Tests/UnitTests.xml
+```
+
+The unit tests cover the LM Studio HTTP client, the meta-description service
+(prompt construction, JSON-schema response parsing, length enforcement,
+mid-word cleanup, German content), and the extension settings DTO. They use
+mocked HTTP, so they run without LM Studio.
+
+A live integration check against a real LM Studio instance is documented in
+the PR description for #1.
+
+## Privacy
+
+All inference happens on `localhost:1234`. The extension never makes outbound
+network calls beyond the configured endpoint. No content, no metadata, no
+analytics is sent to any third party.
+
+## License
+
+MIT — see `composer.json`.

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.0" xmlns:t3="http://typo3.org/schemas/xliff">
+    <file source-language="en" datatype="plaintext" original="messages" date="2026-04-26T00:00:00Z" product-name="ai_editorial_helper">
+        <header/>
+        <body>
+            <trans-unit id="wizard.generate">
+                <source>Generate with AI</source>
+            </trans-unit>
+            <trans-unit id="wizard.generating">
+                <source>Generating…</source>
+            </trans-unit>
+            <trans-unit id="notification.title">
+                <source>AI Editorial Helper</source>
+            </trans-unit>
+            <trans-unit id="notification.success">
+                <source>Meta description and SEO title generated. Review and save.</source>
+            </trans-unit>
+            <trans-unit id="notification.unreachable">
+                <source>LM Studio is not reachable. Start LM Studio and load the configured model, then retry.</source>
+            </trans-unit>
+            <trans-unit id="notification.no_model">
+                <source>No model is loaded in LM Studio. Load the configured model in the LM Studio UI and retry.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/Public/JavaScript/meta-description-wizard.js
+++ b/Resources/Public/JavaScript/meta-description-wizard.js
@@ -1,0 +1,123 @@
+/**
+ * AI Editorial Helper — meta-description wizard.
+ *
+ * Mounted as an ES module by GenerateMetaDescriptionWizard. Listens for clicks
+ * on `.ai-editorial-helper-generate` buttons inside the page-edit form, calls
+ * the AJAX endpoint, and patches the result back into the description and
+ * seo_title input fields.
+ */
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
+import Notification from "@typo3/backend/notification.js";
+
+const SELECTOR = ".ai-editorial-helper-generate";
+const BUSY_CLASS = "ai-editorial-helper-busy";
+
+function findInputForField(form, fieldName) {
+  if (!form) {
+    return null;
+  }
+  const escaped = fieldName.replace(/[\\"]/g, "\\$&");
+  return form.querySelector(`[data-formengine-input-name$="[${escaped}]"]`);
+}
+
+function syncHiddenCounterpart(input) {
+  // FormEngine renders a visible <input> plus a hidden counterpart with the
+  // raw `data[...]` name. Updating the visible one needs the hidden one to
+  // mirror the value or the next save will lose the change.
+  const name = input.getAttribute("data-formengine-input-name");
+  if (!name) {
+    return;
+  }
+  const form = input.closest("form");
+  if (!form) {
+    return;
+  }
+  const hidden = form.querySelector(`input[type="hidden"][name="${CSS.escape(name)}"]`);
+  if (hidden && hidden !== input) {
+    hidden.value = input.value;
+  }
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  input.dispatchEvent(new Event("blur", { bubbles: true }));
+}
+
+function setFieldValue(form, fieldName, value) {
+  const input = findInputForField(form, fieldName);
+  if (!input) {
+    return false;
+  }
+  input.value = value;
+  syncHiddenCounterpart(input);
+  return true;
+}
+
+async function handleClick(event) {
+  const button = event.currentTarget;
+  if (button.classList.contains(BUSY_CLASS)) {
+    return;
+  }
+  const pageUid = parseInt(button.dataset.pageUid || "0", 10);
+  if (!pageUid) {
+    Notification.error("AI Editorial Helper", "No page UID — save the page first.");
+    return;
+  }
+
+  const form = button.closest("form");
+  button.classList.add(BUSY_CLASS);
+  button.disabled = true;
+  const originalText = button.textContent;
+  button.textContent = "Generating…";
+
+  try {
+    const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.ai_editorial_helper_meta)
+      .withQueryArguments({ pageUid })
+      .get();
+    const payload = await response.resolve();
+
+    if (!payload || payload.success !== true) {
+      throw new Error(payload && payload.error ? payload.error : "Unknown error");
+    }
+
+    const filledMeta = setFieldValue(form, "description", payload.metaDescription);
+    const filledTitle = setFieldValue(form, "seo_title", payload.seoTitle);
+
+    if (!filledMeta && !filledTitle) {
+      Notification.warning(
+        "AI Editorial Helper",
+        "Generated content but couldn't find description/seo_title fields on this form.",
+      );
+    } else {
+      Notification.success("AI Editorial Helper", "Meta description and SEO title generated. Review and save.");
+    }
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    Notification.error("AI Editorial Helper", message);
+  } finally {
+    button.classList.remove(BUSY_CLASS);
+    button.disabled = false;
+    button.textContent = originalText;
+  }
+}
+
+function bind(root) {
+  root.querySelectorAll(SELECTOR).forEach((button) => {
+    if (button.dataset.aiHelperBound === "1") {
+      return;
+    }
+    button.dataset.aiHelperBound = "1";
+    button.addEventListener("click", handleClick);
+  });
+}
+
+bind(document);
+
+// FormEngine re-renders fields on tab switch / inline expand — re-bind on DOM mutation.
+const observer = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    mutation.addedNodes.forEach((node) => {
+      if (node instanceof HTMLElement) {
+        bind(node);
+      }
+    });
+  }
+});
+observer.observe(document.body, { childList: true, subtree: true });

--- a/Tests/Unit/Service/ExtensionSettingsTest.php
+++ b/Tests/Unit/Service/ExtensionSettingsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Service\ExtensionSettings;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+final class ExtensionSettingsTest extends TestCase
+{
+    public function testReturnsDefaultsWhenConfigurationThrows(): void
+    {
+        $config = $this->createMock(ExtensionConfiguration::class);
+        $config->method('get')->willThrowException(new \RuntimeException('not installed'));
+
+        $settings = new ExtensionSettings($config);
+
+        self::assertSame(ExtensionSettings::DEFAULT_ENDPOINT, $settings->getEndpoint());
+        self::assertSame(ExtensionSettings::DEFAULT_MODEL, $settings->getModel());
+        self::assertSame(ExtensionSettings::DEFAULT_TIMEOUT, $settings->getTimeout());
+        self::assertSame('', $settings->getApiKey());
+        self::assertFalse($settings->hasApiKey());
+    }
+
+    public function testReturnsDefaultsForEmptyValues(): void
+    {
+        $config = $this->mockExtensionConfig([
+            'endpoint' => '',
+            'model' => '   ',
+            'timeout' => '',
+            'apiKey' => '',
+        ]);
+        $settings = new ExtensionSettings($config);
+
+        self::assertSame(ExtensionSettings::DEFAULT_ENDPOINT, $settings->getEndpoint());
+        self::assertSame(ExtensionSettings::DEFAULT_MODEL, $settings->getModel());
+        self::assertSame(ExtensionSettings::DEFAULT_TIMEOUT, $settings->getTimeout());
+    }
+
+    public function testTrimsTrailingSlashFromEndpoint(): void
+    {
+        $config = $this->mockExtensionConfig(['endpoint' => 'http://example.test:9000/v1/']);
+        $settings = new ExtensionSettings($config);
+        self::assertSame('http://example.test:9000/v1', $settings->getEndpoint());
+    }
+
+    public function testReadsCustomValues(): void
+    {
+        $config = $this->mockExtensionConfig([
+            'endpoint' => 'http://lan.local:1234/v1',
+            'model' => 'mistralai/magistral-small-2509',
+            'timeout' => 30,
+            'apiKey' => 'secret-token',
+        ]);
+        $settings = new ExtensionSettings($config);
+
+        self::assertSame('http://lan.local:1234/v1', $settings->getEndpoint());
+        self::assertSame('mistralai/magistral-small-2509', $settings->getModel());
+        self::assertSame(30, $settings->getTimeout());
+        self::assertSame('secret-token', $settings->getApiKey());
+        self::assertTrue($settings->hasApiKey());
+    }
+
+    public function testNonPositiveTimeoutFallsBackToDefault(): void
+    {
+        $config = $this->mockExtensionConfig(['timeout' => -5]);
+        $settings = new ExtensionSettings($config);
+        self::assertSame(ExtensionSettings::DEFAULT_TIMEOUT, $settings->getTimeout());
+    }
+
+    private function mockExtensionConfig(array $values): ExtensionConfiguration
+    {
+        $config = $this->createMock(ExtensionConfiguration::class);
+        $config->method('get')
+            ->with(ExtensionSettings::EXT_KEY)
+            ->willReturn($values);
+        return $config;
+    }
+}

--- a/Tests/Unit/Service/LmStudioClientTest.php
+++ b/Tests/Unit/Service/LmStudioClientTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\ExtensionSettings;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use TYPO3\CMS\Core\Http\RequestFactory;
+
+final class LmStudioClientTest extends TestCase
+{
+    public function testChatReturnsAssistantContent(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->expects(self::once())
+            ->method('request')
+            ->with(
+                'http://localhost:1234/v1/chat/completions',
+                'POST',
+                self::callback(function (array $options): bool {
+                    self::assertArrayHasKey('json', $options);
+                    self::assertSame('qwen/qwen3-14b', $options['json']['model']);
+                    self::assertSame([['role' => 'user', 'content' => 'hi']], $options['json']['messages']);
+                    self::assertSame(60, $options['timeout']);
+                    self::assertSame('application/json', $options['headers']['Content-Type']);
+                    self::assertArrayNotHasKey('Authorization', $options['headers']);
+                    return true;
+                }),
+            )
+            ->willReturn($this->jsonResponse(200, [
+                'choices' => [['message' => ['content' => "  Hello there.  "]]],
+            ]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $result = $client->chat([['role' => 'user', 'content' => 'hi']]);
+
+        self::assertSame('Hello there.', $result);
+    }
+
+    public function testChatJsonSchemaWrapsRequestWithSchemaResponseFormat(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->expects(self::once())
+            ->method('request')
+            ->with(
+                self::anything(),
+                'POST',
+                self::callback(function (array $options): bool {
+                    $rf = $options['json']['response_format'] ?? null;
+                    self::assertSame('json_schema', $rf['type'] ?? null);
+                    self::assertSame('Demo', $rf['json_schema']['name'] ?? null);
+                    self::assertTrue($rf['json_schema']['strict'] ?? false);
+                    self::assertSame(
+                        ['type' => 'object', 'properties' => ['foo' => ['type' => 'integer']]],
+                        $rf['json_schema']['schema'] ?? null,
+                    );
+                    return true;
+                }),
+            )
+            ->willReturn($this->jsonResponse(200, [
+                'choices' => [['message' => ['content' => '{"foo": 1, "bar": "baz"}']]],
+            ]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $result = $client->chatJsonSchema(
+            [['role' => 'user', 'content' => 'p']],
+            'Demo',
+            ['type' => 'object', 'properties' => ['foo' => ['type' => 'integer']]],
+        );
+
+        self::assertSame(['foo' => 1, 'bar' => 'baz'], $result);
+    }
+
+    public function testChatJsonSchemaThrowsOnNonJsonContent(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willReturn($this->jsonResponse(200, [
+            'choices' => [['message' => ['content' => 'I am sorry, no JSON for you.']]],
+        ]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_INVALID_RESPONSE);
+        $client->chatJsonSchema(
+            [['role' => 'user', 'content' => 'p']],
+            'Demo',
+            ['type' => 'object'],
+        );
+    }
+
+    public function testIncludesAuthorizationHeaderWhenApiKeyConfigured(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->expects(self::once())
+            ->method('request')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::callback(function (array $options): bool {
+                    self::assertSame('Bearer s3cr3t', $options['headers']['Authorization']);
+                    return true;
+                }),
+            )
+            ->willReturn($this->jsonResponse(200, [
+                'choices' => [['message' => ['content' => 'ok']]],
+            ]));
+
+        $client = new LmStudioClient($factory, $this->settings(apiKey: 's3cr3t'));
+        $client->chat([['role' => 'user', 'content' => 'hi']]);
+    }
+
+    public function testThrowsUnreachableWhenRequestFactoryThrows(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willThrowException(new \RuntimeException('ECONNREFUSED'));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_UNREACHABLE);
+        $client->chat([['role' => 'user', 'content' => 'hi']]);
+    }
+
+    public function testClassifiesNoModelLoadedFromOpenAiErrorShape(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willReturn($this->jsonResponse(400, [
+            'error' => ['message' => 'No model loaded — load a model in LM Studio first.'],
+        ]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_NO_MODEL_LOADED);
+        $client->chat([['role' => 'user', 'content' => 'hi']]);
+    }
+
+    public function testClassifies404AsNoModelLoaded(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willReturn($this->jsonResponse(404, [
+            'error' => 'unknown route',
+        ]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_NO_MODEL_LOADED);
+        $client->chat([['role' => 'user', 'content' => 'hi']]);
+    }
+
+    public function testHttpErrorCodeForGenericFailure(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willReturn($this->jsonResponse(500, [
+            'error' => ['message' => 'internal server error'],
+        ]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_HTTP_ERROR);
+        $client->chat([['role' => 'user', 'content' => 'hi']]);
+    }
+
+    public function testThrowsInvalidResponseWhenBodyIsNotJson(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willReturn($this->rawResponse(200, '<html>not json</html>'));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_INVALID_RESPONSE);
+        $client->chat([['role' => 'user', 'content' => 'hi']]);
+    }
+
+    public function testIsAvailableFalseOnConnectionError(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willThrowException(new \RuntimeException('refused'));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        self::assertFalse($client->isAvailable());
+    }
+
+    public function testIsAvailableFalseOnEmptyModelList(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willReturn($this->jsonResponse(200, ['data' => []]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        self::assertFalse($client->isAvailable());
+    }
+
+    public function testIsAvailableTrueWhenModelsListed(): void
+    {
+        $factory = $this->createMock(RequestFactory::class);
+        $factory->method('request')->willReturn($this->jsonResponse(200, [
+            'data' => [['id' => 'qwen/qwen3-14b']],
+        ]));
+
+        $client = new LmStudioClient($factory, $this->settings());
+        self::assertTrue($client->isAvailable());
+        self::assertSame(['qwen/qwen3-14b'], $client->listModels());
+    }
+
+    private function settings(
+        string $endpoint = 'http://localhost:1234/v1',
+        string $model = 'qwen/qwen3-14b',
+        int $timeout = 60,
+        string $apiKey = '',
+    ): ExtensionSettings {
+        $settings = $this->createMock(ExtensionSettings::class);
+        $settings->method('getEndpoint')->willReturn(rtrim($endpoint, '/'));
+        $settings->method('getModel')->willReturn($model);
+        $settings->method('getTimeout')->willReturn($timeout);
+        $settings->method('getApiKey')->willReturn($apiKey);
+        $settings->method('hasApiKey')->willReturn($apiKey !== '');
+        return $settings;
+    }
+
+    private function jsonResponse(int $status, array $body): ResponseInterface
+    {
+        return $this->rawResponse($status, json_encode($body, JSON_THROW_ON_ERROR));
+    }
+
+    private function rawResponse(int $status, string $body): ResponseInterface
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('__toString')->willReturn($body);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn($status);
+        $response->method('getBody')->willReturn($stream);
+        return $response;
+    }
+}

--- a/Tests/Unit/Service/MetaDescriptionServiceTest.php
+++ b/Tests/Unit/Service/MetaDescriptionServiceTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+use Kairos\AiEditorialHelper\Service\MetaDescriptionService;
+use PHPUnit\Framework\TestCase;
+
+final class MetaDescriptionServiceTest extends TestCase
+{
+    public function testReturnsTrimmedFieldsFromLlmResponse(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->willReturn([
+                'metaDescription' => '  Discover the joy of cycling on quiet country roads.  ',
+                'seoTitle' => '  Cycling Guide  ',
+            ]);
+
+        $service = new MetaDescriptionService($client);
+        $result = $service->generate('Cycling for Beginners', '<p>Lots of helpful tips.</p>');
+
+        self::assertSame('Discover the joy of cycling on quiet country roads.', $result['metaDescription']);
+        self::assertSame('Cycling Guide', $result['seoTitle']);
+    }
+
+    public function testEnforcesMetaDescriptionMaxLength(): void
+    {
+        $longMeta = str_repeat('Lorem ipsum dolor sit amet. ', 20);
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'metaDescription' => $longMeta,
+            'seoTitle' => 'Title',
+        ]);
+
+        $service = new MetaDescriptionService($client);
+        $result = $service->generate('Title', 'body');
+
+        self::assertLessThanOrEqual(
+            MetaDescriptionService::META_DESCRIPTION_MAX,
+            mb_strlen($result['metaDescription']),
+        );
+        self::assertSame(' ', '' === $result['metaDescription'] ? '' : ' '); // sanity
+        self::assertNotEmpty($result['metaDescription']);
+    }
+
+    public function testEnforcesSeoTitleMaxLength(): void
+    {
+        $longTitle = str_repeat('Cycling tips for beginners ', 5);
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'metaDescription' => 'short meta',
+            'seoTitle' => $longTitle,
+        ]);
+
+        $service = new MetaDescriptionService($client);
+        $result = $service->generate('t', 'b');
+
+        self::assertLessThanOrEqual(
+            MetaDescriptionService::SEO_TITLE_MAX,
+            mb_strlen($result['seoTitle']),
+        );
+    }
+
+    public function testTrimAvoidsCuttingMidWord(): void
+    {
+        // Length 60 max for SEO title. Build a string where cap=60 lands mid-word.
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'metaDescription' => 'meta description here',
+            'seoTitle' => 'Cycling Adventures Across Europe And Beyond — A Comprehensive Guide',
+        ]);
+
+        $service = new MetaDescriptionService($client);
+        $result = $service->generate('t', 'b');
+
+        // Should not end mid-word and not have a trailing dash/comma.
+        self::assertDoesNotMatchRegularExpression('/[\s,;:\-—–]$/u', $result['seoTitle']);
+        self::assertLessThanOrEqual(MetaDescriptionService::SEO_TITLE_MAX, mb_strlen($result['seoTitle']));
+    }
+
+    public function testStripsHtmlAndCollapsesWhitespaceInBody(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(
+                self::callback(function (array $messages): bool {
+                    self::assertSame('system', $messages[0]['role']);
+                    self::assertStringContainsString('SEO copywriter', $messages[0]['content']);
+
+                    $userMsg = $messages[1]['content'];
+                    self::assertStringNotContainsString('<', $userMsg);
+                    self::assertStringContainsString('Hello world.', $userMsg);
+                    // No multiple spaces after collapse.
+                    self::assertDoesNotMatchRegularExpression('/  +/', $userMsg);
+                    return true;
+                }),
+                self::equalTo('AiEditorialMetaResult'),
+                self::callback(function (array $schema): bool {
+                    self::assertSame('object', $schema['type']);
+                    self::assertContains('metaDescription', $schema['required']);
+                    self::assertContains('seoTitle', $schema['required']);
+                    self::assertFalse($schema['additionalProperties']);
+                    self::assertSame(155, $schema['properties']['metaDescription']['maxLength']);
+                    self::assertSame(55, $schema['properties']['seoTitle']['maxLength']);
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn(['metaDescription' => 'm', 'seoTitle' => 's']);
+
+        $service = new MetaDescriptionService($client);
+        $service->generate('Title', "<p>Hello   world.</p>\n\n  <strong>More</strong>");
+    }
+
+    public function testCleansUpMidWordEndingAtCap(): void
+    {
+        // The LLM's schema-bound output landed exactly at the cap mid-word.
+        // After post-trim, the result must end on a word boundary, no longer mid-syllable.
+        $client = $this->createMock(LmStudioClient::class);
+        // 60 chars exactly, ends mid-word "Barrierefreihe"
+        $atCapMidWord = 'Über uns | Berliner Digitalagentur für TYPO3, Barrierefreihe';
+        $client->method('chatJsonSchema')->willReturn([
+            'metaDescription' => 'A short meta',
+            'seoTitle' => $atCapMidWord,
+        ]);
+
+        $service = new MetaDescriptionService($client);
+        $result = $service->generate('t', 'b');
+
+        self::assertLessThanOrEqual(MetaDescriptionService::SEO_TITLE_MAX, mb_strlen($result['seoTitle']));
+        self::assertStringNotContainsString('Barrierefreihe', $result['seoTitle']);
+        self::assertDoesNotMatchRegularExpression('/[\s,;:|\-—–]$/u', $result['seoTitle']);
+    }
+
+    public function testThrowsOnEmptyTitleAndEmptyBody(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $service = new MetaDescriptionService($client);
+
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_INVALID_RESPONSE);
+        $service->generate('   ', '<p>   </p>');
+    }
+
+    public function testThrowsWhenLlmReturnsEmptyFields(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'metaDescription' => '   ',
+            'seoTitle' => '',
+        ]);
+
+        $service = new MetaDescriptionService($client);
+        $this->expectException(LmStudioException::class);
+        $service->generate('Title', 'body content');
+    }
+
+    public function testPropagatesUnreachableException(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willThrowException(
+            new LmStudioException('refused', LmStudioException::CODE_UNREACHABLE),
+        );
+
+        $service = new MetaDescriptionService($client);
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_UNREACHABLE);
+        $service->generate('Title', 'Body content here.');
+    }
+
+    public function testHandlesEmptyBodyButNonEmptyTitle(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'metaDescription' => 'A page about widgets.',
+            'seoTitle' => 'Widgets',
+        ]);
+
+        $service = new MetaDescriptionService($client);
+        $result = $service->generate('Widgets', '');
+        self::assertSame('A page about widgets.', $result['metaDescription']);
+    }
+
+    public function testGermanContentPassesThrough(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(self::callback(function (array $messages): bool {
+                self::assertStringContainsString('Über uns', $messages[1]['content']);
+                self::assertStringContainsString('Geschäftsbericht', $messages[1]['content']);
+                return true;
+            }))
+            ->willReturn(['metaDescription' => 'Beschreibung der Seite.', 'seoTitle' => 'Über uns']);
+
+        $service = new MetaDescriptionService($client);
+        $result = $service->generate('Über uns', 'Geschäftsbericht 2025 mit Umlauten: ÄÖÜß.');
+        self::assertSame('Über uns', $result['seoTitle']);
+    }
+}

--- a/Tests/UnitTests.xml
+++ b/Tests/UnitTests.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    bootstrap="../vendor/autoload.php"
+    cacheDirectory=".phpunit.cache"
+    colors="true"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnIncomplete="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">../Classes</directory>
+        </include>
+    </source>
+</phpunit>

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,42 @@
     "description": "AI Editorial Helper — local-LLM-powered TYPO3 backend assistant",
     "license": "MIT",
     "require": {
+        "php": "^8.2",
         "typo3/cms-core": "^13.0",
         "typo3/cms-backend": "^13.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^10.5",
+        "typo3/testing-framework": "^8.0",
+        "friendsofphp/php-cs-fixer": "^3.50",
+        "phpstan/phpstan": "^1.10"
+    },
     "extra": {
         "typo3/cms": {
-            "extension-key": "ai_editorial_helper"
+            "extension-key": "ai_editorial_helper",
+            "web-dir": ".Build/Web"
         }
     },
     "autoload": {
         "psr-4": {
             "Kairos\\AiEditorialHelper\\": "Classes/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Kairos\\AiEditorialHelper\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "typo3/cms-composer-installers": true,
+            "typo3/class-alias-loader": true
+        }
+    },
+    "scripts": {
+        "test:unit": "phpunit -c Tests/UnitTests.xml",
+        "test:lint": "php-cs-fixer fix --dry-run --diff",
+        "test:stan": "phpstan analyse Classes Tests --level=6"
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,11 @@
+# cat=connection; type=string; label=LM Studio endpoint URL: OpenAI-compatible base URL exposed by LM Studio (e.g. http://localhost:1234/v1)
+endpoint = http://localhost:1234/v1
+
+# cat=connection; type=string; label=Default model identifier: Model name as listed by LM Studio's /v1/models endpoint (e.g. qwen/qwen3-14b)
+model = qwen/qwen3-14b
+
+# cat=connection; type=int+; label=Request timeout (seconds): How long to wait for an LM Studio response before giving up
+timeout = 60
+
+# cat=connection; type=string; label=API key (optional): Sent as Bearer token if non-empty. LM Studio does not require one for local use; leave blank unless your setup needs it.
+apiKey =


### PR DESCRIPTION
Implements [#1](https://github.com/backant-io/typo3-ai-helper/issues/1). First feature of the AI Editorial Helper extension and the foundation for issues #2-#6.

## What's included

- **`Classes/Service/LmStudioClient.php`** — shared HTTP wrapper for LM Studio's OpenAI-compatible API. `chat()` for free-form, `chatJsonSchema()` for grammar-constrained JSON. Typed `LmStudioException` codes for `UNREACHABLE`, `NO_MODEL_LOADED`, `INVALID_RESPONSE`, `HTTP_ERROR` so the UI surfaces a useful message instead of a stack trace.
- **`Classes/Service/ExtensionSettings.php`** — typed reader for the four `ext_conf_template.txt` settings (endpoint, model, timeout, apiKey) with documented defaults.
- **`Classes/Service/MetaDescriptionService.php`** — produces `{ metaDescription, seoTitle }` from a page's title + body. Schema caps at 155 / 55 chars; post-trim enforces the public **160 / 60** caps with word-boundary backoff (no mid-syllable cuts).
- **`Classes/Controller/Ajax/MetaDescriptionAjaxController.php`** + `Configuration/Backend/AjaxRoutes.php` — backend AJAX endpoint that loads the page record, concatenates default-language `tt_content`, and returns JSON.
- **`Classes/Form/FieldWizard/GenerateMetaDescriptionWizard.php`** + `Configuration/TCA/Overrides/pages.php` — registers a custom fieldWizard that injects a *Generate with AI* button next to the **Description** and **SEO Title** fields on the page-edit form.
- **`Resources/Public/JavaScript/meta-description-wizard.js`** — ES module (registered via `Configuration/JavaScriptModules.php`) that calls the AJAX route, patches results into the form fields, mirrors the hidden FormEngine counterpart, and uses a `MutationObserver` to handle tab-switch re-renders.

## Why `json_schema` instead of `json_object`

The original ticket text called for `response_format: { type: "json_object" }` (the older OpenAI shorthand). Live testing against LM Studio surfaced:

```
{"error":"'response_format.type' must be 'json_schema' or 'text'"}
```

LM Studio uses **`json_schema`** — grammar-constrained sampling against a JSON Schema, which is strictly more powerful (the schema enforces structure during generation, so the response is guaranteed to parse). I swapped to that and it works cleanly. Documented in code + README.

## Tests — 28 / 28 ✓

```
$ docker run --rm -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit -c Tests/UnitTests.xml --testdox
…
OK (28 tests, 85 assertions)
```

- `ExtensionSettingsTest` — defaults, trimming, custom values, invalid timeout
- `LmStudioClientTest` — request shape, schema `response_format`, auth header, error classification (404 → no-model, OpenAI-shape 400 → no-model, generic 5xx → http-error, connection error → unreachable, non-JSON → invalid-response), `isAvailable()`, `listModels()`
- `MetaDescriptionServiceTest` — trim, length enforcement, **mid-word backoff at cap** (regression for the LM Studio at-limit truncation behavior), HTML stripping, German Umlaut content, error propagation

## Live integration check (LM Studio with qwen/qwen3-14b loaded)

| Input | Output |
|---|---|
| DE: *"Wir sind eine Berliner Digitalagentur mit Fokus auf TYPO3, Barrierefreiheit und Performance. Seit 2012 betreuen wir Kunden im DACH-Raum."* | meta (101): *"Berliner Digitalagentur mit Fokus auf TYPO3, Barrierefreiheit und Performance seit 2012 im DACH-Raum."*<br>title (34): *"Über uns \| Berliner Digitalagentur"* |
| EN: *"A friendly guide to your first 100 km on two wheels…"* | meta (92): *"A friendly guide for beginners covering gear, route planning, fueling and rain preparedness."*<br>title (54): *"Cycling for Beginners \| A Friendly Guide to Your First"* |

Both within caps, both end on word boundaries.

## Acceptance-criteria checklist

- [x] `LmStudioClient.php` speaking `/v1/chat/completions`, configurable endpoint + model via `ext_conf_template.txt` and `ExtensionConfiguration`.
- [x] `MetaDescriptionService.php` returning `{ metaDescription, seoTitle }` via German-aware prompt.
- [x] Backend integration on the page-properties form (TCA fieldWizard + AJAX route + ES module).
- [x] PHPUnit tests for both services.
- [x] 160 / 60 char caps enforced (prompt + schema + post-trim).
- [x] Composer autoload resolves (PSR-4 maps `Kairos\AiEditorialHelper\` and `Kairos\AiEditorialHelper\Tests\`).
- [x] Extension installs cleanly into a v13 instance (composer install passes against `typo3/cms-core:^13.0`).
- [x] Graceful errors when LM Studio is unreachable or no model is loaded — surfaced via backend Notification, not stack traces.

## Notes for the reviewer

- `php` and `composer` aren't installed locally on the dev machine, so all PHP work was done through `docker run --rm php:8.4-cli` (PHP 8.3 fails the platform check from `typo3/cms-core` deps; 8.4 is fine).
- No CI workflow yet (kairos permissions block writing to `.github/workflows/`). I'll file a follow-up issue to request CI.
- Issues #2-#6 will reuse `LmStudioClient`. The `chatJsonSchema` API is shaped for that — each future service defines its own JSON Schema.

Closes #1.