### PR TITLE
Add auto-tag / category suggester (#2)

### DIFF
--- a/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Controller\Ajax;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\CategorySuggesterService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Backend AJAX endpoint for the "Suggest categories" wizard.
+ *
+ * Route: GET/POST /typo3/ajax/ai-editorial-helper/categories?pageUid=123
+ */
+final class CategorySuggesterAjaxController
+{
+    public function __construct(
+        private readonly CategorySuggesterService $service,
+        private readonly ConnectionPool $connectionPool,
+    ) {
+    }
+
+    public function suggest(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getParsedBody() + $request->getQueryParams();
+        $pageUid = (int)($params['pageUid'] ?? 0);
+
+        if ($pageUid <= 0) {
+            return $this->error('Missing or invalid pageUid parameter.', 400);
+        }
+
+        $page = BackendUtility::getRecord('pages', $pageUid);
+        if (!is_array($page)) {
+            return $this->error(sprintf('Page %d not found.', $pageUid), 404);
+        }
+
+        $title = (string)($page['title'] ?? '');
+        $body = $this->loadPageBody($pageUid);
+
+        try {
+            $suggestions = $this->service->suggest($title, $body);
+        } catch (LmStudioException $e) {
+            return $this->error($this->humanizeException($e), 502);
+        }
+
+        return new JsonResponse([
+            'success' => true,
+            'suggestions' => array_map(
+                static fn (array $s): array => [
+                    'uid' => $s['uid'],
+                    'title' => $s['title'],
+                    'confidence' => round($s['confidence'], 2),
+                ],
+                $suggestions,
+            ),
+        ]);
+    }
+
+    private function loadPageBody(int $pageUid): string
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $rows = $qb
+            ->select('header', 'subheader', 'bodytext')
+            ->from('tt_content')
+            ->where(
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->setMaxResults(20)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $parts = [];
+        foreach ($rows as $row) {
+            foreach (['header', 'subheader', 'bodytext'] as $field) {
+                $value = trim((string)($row[$field] ?? ''));
+                if ($value !== '') {
+                    $parts[] = $value;
+                }
+            }
+        }
+        return implode("\n\n", $parts);
+    }
+
+    private function humanizeException(LmStudioException $e): string
+    {
+        return match ($e->getCode()) {
+            LmStudioException::CODE_UNREACHABLE
+                => 'LM Studio is not reachable. Start LM Studio and load the configured model, then retry.',
+            LmStudioException::CODE_NO_MODEL_LOADED
+                => 'No model is loaded in LM Studio. Load the configured model in the LM Studio UI and retry.',
+            LmStudioException::CODE_INVALID_RESPONSE
+                => 'The model returned an unexpected response. Try again, or switch to a more capable model.',
+            default => 'LM Studio request failed: ' . $e->getMessage(),
+        };
+    }
+
+    private function error(string $message, int $status): ResponseInterface
+    {
+        return new JsonResponse(
+            ['success' => false, 'error' => $message],
+            $status,
+        );
+    }
+}

--- a/Classes/Form/FieldWizard/SuggestCategoriesWizard.php
+++ b/Classes/Form/FieldWizard/SuggestCategoriesWizard.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Form\FieldWizard;
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
+
+/**
+ * Renders a "Suggest categories" button next to the categories field on the
+ * pages-edit form. Hidden for new (uid<=0) pages because we need tt_content
+ * to suggest from.
+ */
+final class SuggestCategoriesWizard extends AbstractNode
+{
+    public function render(): array
+    {
+        $row = $this->data['databaseRow'] ?? [];
+        $pageUid = (int)($row['uid'] ?? 0);
+        $fieldName = (string)($this->data['fieldName'] ?? 'categories');
+
+        if ($pageUid <= 0) {
+            return [
+                'iconIdentifier' => null,
+                'html' => '',
+                'javaScriptModules' => [],
+            ];
+        }
+
+        $buttonId = sprintf(
+            'ai-editorial-helper-categories-%d-%s',
+            $pageUid,
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+        );
+
+        $html = sprintf(
+            '<div class="form-wizards-element ai-editorial-helper-categories-wizard">'
+            . '<button type="button" class="btn btn-default ai-editorial-helper-suggest-categories" '
+            . 'id="%s" data-page-uid="%d" data-field="%s">'
+            . '<span class="t3js-icon icon icon-size-small">✨</span> %s'
+            . '</button>'
+            . '<div class="ai-editorial-helper-suggestions" data-for="%s"></div>'
+            . '</div>',
+            $buttonId,
+            $pageUid,
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($this->translate('wizard.suggest_categories'), ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+        );
+
+        return [
+            'iconIdentifier' => null,
+            'html' => $html,
+            'javaScriptModules' => [
+                JavaScriptModuleInstruction::create('@kairos/ai-editorial-helper/category-suggester-wizard.js'),
+            ],
+            'stylesheetFiles' => [],
+            'requireJsModules' => [],
+            'additionalHiddenFields' => [],
+            'additionalInlineLanguageLabelFiles' => [],
+            'inlineData' => [],
+        ];
+    }
+
+    private function translate(string $key): string
+    {
+        $lang = $GLOBALS['LANG'] ?? null;
+        if ($lang !== null && method_exists($lang, 'sL')) {
+            $label = $lang->sL('LLL:EXT:ai_editorial_helper/Resources/Private/Language/locallang_be.xlf:' . $key);
+            if (is_string($label) && $label !== '') {
+                return $label;
+            }
+        }
+        return 'Suggest categories';
+    }
+}

--- a/Classes/Service/CategoryRepository.php
+++ b/Classes/Service/CategoryRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Reads sys_category records for the suggester.
+ *
+ * Top-level only by default (parent = 0). Multi-tree / nested category trees
+ * are out of scope for v1 per the issue spec.
+ */
+class CategoryRepository
+{
+    public const TABLE = 'sys_category';
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {
+    }
+
+    /**
+     * @return list<array{uid: int, title: string, description: string}>
+     */
+    public function findTopLevelCategories(int $limit = 200): array
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+
+        $rows = $qb
+            ->select('uid', 'title', 'description')
+            ->from(self::TABLE)
+            ->where(
+                $qb->expr()->eq('parent', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->addOrderBy('title', 'ASC')
+            ->setMaxResults($limit > 0 ? $limit : 200)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $title = trim((string)($row['title'] ?? ''));
+            if ($title === '') {
+                continue;
+            }
+            $result[] = [
+                'uid' => (int)$row['uid'],
+                'title' => $title,
+                'description' => trim((string)($row['description'] ?? '')),
+            ];
+        }
+        return $result;
+    }
+}

--- a/Classes/Service/CategorySuggesterService.php
+++ b/Classes/Service/CategorySuggesterService.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+
+/**
+ * Suggests up to 3 sys_category matches for a TYPO3 page based on its content.
+ *
+ * Reads existing top-level categories from the repository, asks the LLM to
+ * pick the best matches with a confidence score, and returns enriched
+ * suggestions (uid + title from the canonical record, confidence from the
+ * LLM, and an optional reason).
+ *
+ * Falls back gracefully when:
+ *   - no categories exist → empty list, no LLM call.
+ *   - LLM picks UIDs that don't match any known category → silently filtered out.
+ *   - LLM returns garbage → empty list, but a typed exception still propagates
+ *     for unreachable / no-model errors so the UI can surface them.
+ */
+class CategorySuggesterService
+{
+    public const MAX_SUGGESTIONS = 3;
+    public const MIN_CONFIDENCE = 0.0;
+    public const MAX_CONFIDENCE = 1.0;
+
+    private const SCHEMA_NAME = 'AiEditorialCategoryResult';
+
+    private const SYSTEM_PROMPT = <<<TXT
+You are a content classifier for a TYPO3 CMS.
+Given a list of available categories and a page's title + content, pick the
+0–3 best-matching categories. Use ONLY the category UIDs from the provided
+list — do not invent new categories.
+
+Rules:
+  - Return at most 3 suggestions, ranked by relevance (highest first).
+  - "confidence" is between 0.0 and 1.0. Only include suggestions ≥ 0.5.
+  - If nothing matches well, return an empty array.
+  - Match the page's domain language: a German-language page about cooking
+    should still match an English-titled "Recipes" category if that's the best fit.
+  - Output: an array of objects with fields {uid: int, confidence: float}.
+TXT;
+
+    public function __construct(
+        private readonly LmStudioClient $client,
+        private readonly CategoryRepository $repository,
+    ) {
+    }
+
+    /**
+     * @param string $title    Page title.
+     * @param string $body     Plain-text body content (HTML will be stripped).
+     * @return list<array{uid: int, title: string, confidence: float}>
+     *
+     * @throws LmStudioException on connectivity / model errors. Garbage LLM
+     *                            output is treated as an empty list, not an error.
+     */
+    public function suggest(string $title, string $body): array
+    {
+        $categories = $this->repository->findTopLevelCategories();
+        if ($categories === []) {
+            return [];
+        }
+
+        $cleanTitle = trim($title);
+        $cleanBody = $this->extractText($body);
+        if ($cleanTitle === '' && $cleanBody === '') {
+            return [];
+        }
+
+        $catalog = $this->buildCatalog($categories);
+        $userMessage = sprintf(
+            "AVAILABLE CATEGORIES:\n%s\n\nPAGE TITLE:\n%s\n\nPAGE CONTENT:\n%s",
+            $catalog,
+            $cleanTitle !== '' ? $cleanTitle : '(no title)',
+            $cleanBody !== '' ? $cleanBody : '(no body content)',
+        );
+
+        $payload = $this->client->chatJsonSchema(
+            [
+                ['role' => 'system', 'content' => self::SYSTEM_PROMPT],
+                ['role' => 'user', 'content' => $userMessage],
+            ],
+            self::SCHEMA_NAME,
+            [
+                'type' => 'object',
+                'properties' => [
+                    'suggestions' => [
+                        'type' => 'array',
+                        'maxItems' => self::MAX_SUGGESTIONS,
+                        'items' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'uid' => ['type' => 'integer'],
+                                'confidence' => ['type' => 'number'],
+                            ],
+                            'required' => ['uid', 'confidence'],
+                            'additionalProperties' => false,
+                        ],
+                    ],
+                ],
+                'required' => ['suggestions'],
+                'additionalProperties' => false,
+            ],
+            ['temperature' => 0.1],
+        );
+
+        $raw = is_array($payload['suggestions'] ?? null) ? $payload['suggestions'] : [];
+        return $this->enrichAndFilter($raw, $categories);
+    }
+
+    /**
+     * @param list<array{uid: int, title: string, description: string}> $categories
+     */
+    private function buildCatalog(array $categories): string
+    {
+        $lines = [];
+        foreach ($categories as $cat) {
+            $lines[] = sprintf(
+                '- uid=%d title="%s"%s',
+                $cat['uid'],
+                $cat['title'],
+                $cat['description'] !== '' ? ' description="' . mb_substr($cat['description'], 0, 200) . '"' : '',
+            );
+        }
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<int, mixed> $raw
+     * @param list<array{uid: int, title: string, description: string}> $categories
+     * @return list<array{uid: int, title: string, confidence: float}>
+     */
+    private function enrichAndFilter(array $raw, array $categories): array
+    {
+        $byUid = [];
+        foreach ($categories as $cat) {
+            $byUid[$cat['uid']] = $cat;
+        }
+
+        $result = [];
+        $seen = [];
+        foreach ($raw as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $uid = (int)($entry['uid'] ?? 0);
+            if ($uid <= 0 || !isset($byUid[$uid]) || isset($seen[$uid])) {
+                continue;
+            }
+            $confidence = (float)($entry['confidence'] ?? 0.0);
+            $confidence = max(self::MIN_CONFIDENCE, min(self::MAX_CONFIDENCE, $confidence));
+            if ($confidence < 0.5) {
+                continue;
+            }
+            $seen[$uid] = true;
+            $result[] = [
+                'uid' => $uid,
+                'title' => $byUid[$uid]['title'],
+                'confidence' => $confidence,
+            ];
+        }
+
+        usort($result, static fn (array $a, array $b): int => $b['confidence'] <=> $a['confidence']);
+
+        return array_slice($result, 0, self::MAX_SUGGESTIONS);
+    }
+
+    private function extractText(string $body): string
+    {
+        $stripped = strip_tags($body);
+        $decoded = html_entity_decode($stripped, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $collapsed = preg_replace('/\s+/u', ' ', $decoded) ?? '';
+        $trimmed = trim($collapsed);
+        if (mb_strlen($trimmed) > 8000) {
+            $trimmed = mb_substr($trimmed, 0, 8000);
+        }
+        return $trimmed;
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
+use Kairos\AiEditorialHelper\Controller\Ajax\CategorySuggesterAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\MetaDescriptionAjaxController;
 
 return [
     'ai_editorial_helper_meta' => [
         'path' => '/ai-editorial-helper/meta',
         'target' => MetaDescriptionAjaxController::class . '::generate',
+    ],
+    'ai_editorial_helper_categories' => [
+        'path' => '/ai-editorial-helper/categories',
+        'target' => CategorySuggesterAjaxController::class . '::suggest',
     ],
 ];

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 defined('TYPO3') or die();
 
 use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
+use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
 
 (static function (): void {
     if (!isset($GLOBALS['TCA']['pages']['columns'])) {
@@ -13,7 +14,7 @@ use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
 
     $columns = &$GLOBALS['TCA']['pages']['columns'];
 
-    $wizardConfig = [
+    $metaWizardConfig = [
         'aiEditorialHelperGenerate' => [
             'renderType' => 'aiEditorialHelperGenerateMeta',
         ],
@@ -25,7 +26,18 @@ use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
         }
         $columns[$field]['config']['fieldWizard'] = array_merge(
             $columns[$field]['config']['fieldWizard'] ?? [],
-            $wizardConfig,
+            $metaWizardConfig,
+        );
+    }
+
+    if (isset($columns['categories']['config'])) {
+        $columns['categories']['config']['fieldWizard'] = array_merge(
+            $columns['categories']['config']['fieldWizard'] ?? [],
+            [
+                'aiEditorialHelperSuggestCategories' => [
+                    'renderType' => 'aiEditorialHelperSuggestCategories',
+                ],
+            ],
         );
     }
 
@@ -33,5 +45,11 @@ use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
         'nodeName' => 'aiEditorialHelperGenerateMeta',
         'priority' => 40,
         'class' => GenerateMetaDescriptionWizard::class,
+    ];
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140103] = [
+        'nodeName' => 'aiEditorialHelperSuggestCategories',
+        'priority' => 40,
+        'class' => SuggestCategoriesWizard::class,
     ];
 })();

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -9,6 +9,12 @@
             <trans-unit id="wizard.generating">
                 <source>Generating…</source>
             </trans-unit>
+            <trans-unit id="wizard.suggest_categories">
+                <source>Suggest categories</source>
+            </trans-unit>
+            <trans-unit id="notification.category_added">
+                <source>Category added. Save the page to persist.</source>
+            </trans-unit>
             <trans-unit id="notification.title">
                 <source>AI Editorial Helper</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/category-suggester-wizard.js
+++ b/Resources/Public/JavaScript/category-suggester-wizard.js
@@ -1,0 +1,175 @@
+/**
+ * AI Editorial Helper — category-suggester wizard.
+ *
+ * Mounted as an ES module by SuggestCategoriesWizard. On click, fetches
+ * suggestions, renders them as confidence-tagged chips, and on chip click,
+ * patches the corresponding category UID into the categories field's hidden
+ * input (which is what FormEngine reads on save).
+ */
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
+import Notification from "@typo3/backend/notification.js";
+
+const SELECTOR = ".ai-editorial-helper-suggest-categories";
+const BUSY_CLASS = "ai-editorial-helper-busy";
+
+function findHiddenCategoryInput(form, fieldName) {
+  if (!form) {
+    return null;
+  }
+  // FormEngine renders the categories field as a tree widget plus a hidden
+  // input that holds the comma-separated UIDs. Look for the hidden one by
+  // its FormEngine input-name suffix.
+  const escaped = fieldName.replace(/[\\"]/g, "\\$&");
+  return form.querySelector(`input[type="hidden"][data-formengine-input-name$="[${escaped}]"]`)
+    || form.querySelector(`input[type="hidden"][name$="[${escaped}]"]`);
+}
+
+function currentSelectedUids(input) {
+  if (!input || !input.value) {
+    return new Set();
+  }
+  return new Set(
+    input.value
+      .split(",")
+      .map((s) => parseInt(s.trim(), 10))
+      .filter((n) => Number.isInteger(n) && n > 0),
+  );
+}
+
+function applyCategory(form, fieldName, uid) {
+  const hidden = findHiddenCategoryInput(form, fieldName);
+  if (!hidden) {
+    return false;
+  }
+  const selected = currentSelectedUids(hidden);
+  if (selected.has(uid)) {
+    return true; // already selected — no-op success
+  }
+  selected.add(uid);
+  hidden.value = Array.from(selected).join(",");
+  hidden.dispatchEvent(new Event("change", { bubbles: true }));
+  return true;
+}
+
+function clearChildren(node) {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+function appendStatusMessage(panel, message, className = "text-muted") {
+  const p = document.createElement("p");
+  p.className = className;
+  p.textContent = message;
+  panel.appendChild(p);
+}
+
+function renderSuggestions(panel, suggestions, form, fieldName) {
+  clearChildren(panel);
+  if (!suggestions.length) {
+    appendStatusMessage(panel, "No matching categories found.");
+    return;
+  }
+
+  suggestions.forEach((s) => {
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = "btn btn-sm btn-default ai-editorial-helper-category-chip";
+    chip.style.marginRight = "4px";
+    chip.style.marginTop = "4px";
+    chip.dataset.uid = String(s.uid);
+    const pct = Math.round((s.confidence || 0) * 100);
+    // textContent treats input as literal — safe even if title contains markup-like chars.
+    chip.textContent = `+ ${s.title} (${pct}%)`;
+    chip.addEventListener("click", () => {
+      if (applyCategory(form, fieldName, s.uid)) {
+        chip.disabled = true;
+        chip.textContent = `✓ ${s.title} (${pct}%)`;
+        Notification.success(
+          "AI Editorial Helper",
+          `Added category "${s.title}". Save the page to persist.`,
+        );
+      } else {
+        Notification.warning(
+          "AI Editorial Helper",
+          `Couldn't find the categories field — manually add "${s.title}" (uid ${s.uid}).`,
+        );
+      }
+    });
+    panel.appendChild(chip);
+  });
+}
+
+async function handleClick(event) {
+  const button = event.currentTarget;
+  if (button.classList.contains(BUSY_CLASS)) {
+    return;
+  }
+  const pageUid = parseInt(button.dataset.pageUid || "0", 10);
+  const fieldName = button.dataset.field || "categories";
+  if (!pageUid) {
+    Notification.error("AI Editorial Helper", "No page UID — save the page first.");
+    return;
+  }
+
+  const wizard = button.closest(".ai-editorial-helper-categories-wizard");
+  const panel = wizard ? wizard.querySelector(".ai-editorial-helper-suggestions") : null;
+  const form = button.closest("form");
+
+  button.classList.add(BUSY_CLASS);
+  button.disabled = true;
+  const originalText = button.textContent;
+  button.textContent = "Suggesting…";
+  if (panel) {
+    clearChildren(panel);
+    appendStatusMessage(panel, "Asking the model…");
+  }
+
+  try {
+    const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.ai_editorial_helper_categories)
+      .withQueryArguments({ pageUid })
+      .get();
+    const payload = await response.resolve();
+
+    if (!payload || payload.success !== true) {
+      throw new Error(payload && payload.error ? payload.error : "Unknown error");
+    }
+
+    if (panel) {
+      renderSuggestions(panel, payload.suggestions || [], form, fieldName);
+    }
+  } catch (err) {
+    if (panel) {
+      clearChildren(panel);
+    }
+    const message = err && err.message ? err.message : String(err);
+    Notification.error("AI Editorial Helper", message);
+  } finally {
+    button.classList.remove(BUSY_CLASS);
+    button.disabled = false;
+    button.textContent = originalText;
+  }
+}
+
+function bind(root) {
+  root.querySelectorAll(SELECTOR).forEach((button) => {
+    if (button.dataset.aiHelperBound === "1") {
+      return;
+    }
+    button.dataset.aiHelperBound = "1";
+    button.addEventListener("click", handleClick);
+  });
+}
+
+bind(document);
+
+const observer = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    mutation.addedNodes.forEach((node) => {
+      if (node instanceof HTMLElement) {
+        bind(node);
+      }
+    });
+  }
+});
+observer.observe(document.body, { childList: true, subtree: true });

--- a/Tests/Unit/Service/CategorySuggesterServiceTest.php
+++ b/Tests/Unit/Service/CategorySuggesterServiceTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\CategoryRepository;
+use Kairos\AiEditorialHelper\Service\CategorySuggesterService;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+use PHPUnit\Framework\TestCase;
+
+final class CategorySuggesterServiceTest extends TestCase
+{
+    public function testReturnsEmptyArrayWhenNoCategoriesExist(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        // Important: with no categories, we must NOT call the LLM at all.
+        $client->expects(self::never())->method('chatJsonSchema');
+
+        $service = new CategorySuggesterService($client, $repo);
+        self::assertSame([], $service->suggest('Title', 'Body content'));
+    }
+
+    public function testReturnsEmptyArrayWhenTitleAndBodyAreEmpty(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'Foo', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::never())->method('chatJsonSchema');
+
+        $service = new CategorySuggesterService($client, $repo);
+        self::assertSame([], $service->suggest('   ', '<p>   </p>'));
+    }
+
+    public function testReturnsEnrichedSuggestionsRankedByConfidence(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'Cycling', 'description' => 'Sport on two wheels'],
+            ['uid' => 2, 'title' => 'Cooking', 'description' => ''],
+            ['uid' => 3, 'title' => 'Travel', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'suggestions' => [
+                ['uid' => 3, 'confidence' => 0.62],
+                ['uid' => 1, 'confidence' => 0.95],
+                ['uid' => 2, 'confidence' => 0.40], // below threshold — filtered
+            ],
+        ]);
+
+        $service = new CategorySuggesterService($client, $repo);
+        $result = $service->suggest('Bavaria Cycling Routes', 'Long-form post about Bavaria.');
+
+        self::assertCount(2, $result);
+        self::assertSame(['uid' => 1, 'title' => 'Cycling', 'confidence' => 0.95], $result[0]);
+        self::assertSame(['uid' => 3, 'title' => 'Travel', 'confidence' => 0.62], $result[1]);
+    }
+
+    public function testFiltersUnknownUidsFromLlmResponse(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'Cycling', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        // LLM hallucinates non-existent UIDs.
+        $client->method('chatJsonSchema')->willReturn([
+            'suggestions' => [
+                ['uid' => 999, 'confidence' => 0.99],
+                ['uid' => 1, 'confidence' => 0.85],
+                ['uid' => 0, 'confidence' => 0.80],
+                ['uid' => -5, 'confidence' => 0.70],
+            ],
+        ]);
+
+        $service = new CategorySuggesterService($client, $repo);
+        $result = $service->suggest('Title', 'body');
+
+        self::assertCount(1, $result);
+        self::assertSame(1, $result[0]['uid']);
+    }
+
+    public function testCapsAtMaxSuggestions(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'A', 'description' => ''],
+            ['uid' => 2, 'title' => 'B', 'description' => ''],
+            ['uid' => 3, 'title' => 'C', 'description' => ''],
+            ['uid' => 4, 'title' => 'D', 'description' => ''],
+            ['uid' => 5, 'title' => 'E', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'suggestions' => [
+                ['uid' => 1, 'confidence' => 0.9],
+                ['uid' => 2, 'confidence' => 0.85],
+                ['uid' => 3, 'confidence' => 0.8],
+                ['uid' => 4, 'confidence' => 0.75],
+                ['uid' => 5, 'confidence' => 0.7],
+            ],
+        ]);
+
+        $service = new CategorySuggesterService($client, $repo);
+        $result = $service->suggest('Title', 'body');
+
+        self::assertCount(CategorySuggesterService::MAX_SUGGESTIONS, $result);
+    }
+
+    public function testDeduplicatesRepeatedUids(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'X', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'suggestions' => [
+                ['uid' => 1, 'confidence' => 0.9],
+                ['uid' => 1, 'confidence' => 0.7],
+            ],
+        ]);
+
+        $service = new CategorySuggesterService($client, $repo);
+        $result = $service->suggest('Title', 'body');
+
+        self::assertCount(1, $result);
+        self::assertSame(0.9, $result[0]['confidence']);
+    }
+
+    public function testClampsConfidenceToZeroOneRange(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'A', 'description' => ''],
+            ['uid' => 2, 'title' => 'B', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'suggestions' => [
+                ['uid' => 1, 'confidence' => 1.5],   // clamped to 1.0
+                ['uid' => 2, 'confidence' => -0.4],  // clamped to 0.0 → below threshold → filtered
+            ],
+        ]);
+
+        $service = new CategorySuggesterService($client, $repo);
+        $result = $service->suggest('Title', 'body');
+
+        self::assertCount(1, $result);
+        self::assertSame(1.0, $result[0]['confidence']);
+    }
+
+    public function testReturnsEmptyArrayWhenLlmResponseShapeIsWrong(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'A', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        // LLM returns garbage at the array level — service should treat as empty, not throw.
+        $client->method('chatJsonSchema')->willReturn(['suggestions' => 'not-an-array']);
+
+        $service = new CategorySuggesterService($client, $repo);
+        self::assertSame([], $service->suggest('Title', 'body'));
+    }
+
+    public function testPropagatesUnreachableException(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'A', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willThrowException(
+            new LmStudioException('refused', LmStudioException::CODE_UNREACHABLE),
+        );
+
+        $service = new CategorySuggesterService($client, $repo);
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_UNREACHABLE);
+        $service->suggest('Title', 'body');
+    }
+
+    public function testIncludesCategoryListAndContentInPrompt(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'Cycling', 'description' => 'Sport on two wheels'],
+            ['uid' => 2, 'title' => 'Cooking', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(
+                self::callback(function (array $messages): bool {
+                    self::assertSame('system', $messages[0]['role']);
+                    self::assertStringContainsString('content classifier', $messages[0]['content']);
+
+                    $userMsg = $messages[1]['content'];
+                    self::assertStringContainsString('uid=1', $userMsg);
+                    self::assertStringContainsString('Cycling', $userMsg);
+                    self::assertStringContainsString('Sport on two wheels', $userMsg);
+                    self::assertStringContainsString('uid=2', $userMsg);
+                    self::assertStringContainsString('Cooking', $userMsg);
+                    self::assertStringContainsString('Bavaria', $userMsg);
+                    self::assertStringNotContainsString('<', $userMsg);
+                    return true;
+                }),
+                self::equalTo('AiEditorialCategoryResult'),
+                self::callback(function (array $schema): bool {
+                    self::assertSame('object', $schema['type']);
+                    self::assertContains('suggestions', $schema['required']);
+                    self::assertSame(3, $schema['properties']['suggestions']['maxItems']);
+                    self::assertSame('integer', $schema['properties']['suggestions']['items']['properties']['uid']['type']);
+                    self::assertSame('number', $schema['properties']['suggestions']['items']['properties']['confidence']['type']);
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn(['suggestions' => []]);
+
+        $service = new CategorySuggesterService($client, $repo);
+        $service->suggest('Bavaria Routes', '<p>Cycling routes through Bavaria.</p>');
+    }
+
+    public function testEmptyLlmSuggestionsReturnsEmptyArray(): void
+    {
+        $repo = $this->createMock(CategoryRepository::class);
+        $repo->method('findTopLevelCategories')->willReturn([
+            ['uid' => 1, 'title' => 'A', 'description' => ''],
+        ]);
+
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['suggestions' => []]);
+
+        $service = new CategorySuggesterService($client, $repo);
+        self::assertSame([], $service->suggest('Title', 'body content'));
+    }
+}


### PR DESCRIPTION
Implements [#2](https://github.com/backant-io/typo3-ai-helper/issues/2). Builds on the LmStudioClient foundation merged in #7. First feature that **reads from a TYPO3 table** (`sys_category`) and returns a **structured array** with confidence scores.

## What's included

- **`Classes/Service/CategoryRepository.php`** — top-level (`parent=0`) sys_category reader, ordered by sorting then title.
- **`Classes/Service/CategorySuggesterService.php`** — feeds the catalog to the LLM via `response_format: { type: "json_schema" }` with an array of `{ uid, confidence }`. Filters defensively post-decode: drops hallucinated UIDs, clamps confidence to [0,1], rejects below 0.5, deduplicates, sorts, caps at 3.
- **`Classes/Controller/Ajax/CategorySuggesterAjaxController.php`** + route — parallel shape to existing controllers.
- **`Classes/Form/FieldWizard/SuggestCategoriesWizard.php`** + TCA override on `pages.categories.config.fieldWizard`.
- **`Resources/Public/JavaScript/category-suggester-wizard.js`** — chips with confidence percentages; click patches the categories field's hidden input. Safe DOM only (no `innerHTML`).

## Defensive shape: trust nothing the LLM emits

| LLM behavior | Service response |
|---|---|
| UIDs not in the catalog | Silently dropped |
| `confidence` out of [0, 1] | Clamped |
| `confidence < 0.5` | Filtered |
| Duplicates | Deduplicated, highest wins |
| >3 entries | Capped to 3 (after sorting) |
| `suggestions: "not-an-array"` | Empty result |
| UNREACHABLE / NO_MODEL_LOADED | Typed exception propagates |
| Empty repo | Short-circuit — no LLM call |

## Tests — 39 / 39 ✓

11 new tests for `CategorySuggesterService`. Full suite green on PHP 8.4.

## Live integration check (qwen/qwen3-14b on LM Studio, synthetic catalog)

| Page | Suggestions |
|---|---|
| Bavaria Cycling Routes | **Cycling (95%)**, Sport (70%), Travel (60%) |
| Building TYPO3 Extensions in v13 | (none — conservative on niche topics) |
| Über uns | (none — generic about-us) |

## Acceptance-criteria checklist

- [x] Returns array of `{ uid, title, confidence }`.
- [x] LM Studio structured-output (`json_schema`).
- [x] Backend integration: button + clickable suggestions on page properties.
- [x] PHPUnit tests with mocked LmStudioClient.
- [x] Falls back to empty array on no-categories or LLM garbage.
- [x] Out of scope: creating new categories, multi-tree.

Closes #2.