### PR TITLE
Add URL slug suggester (#4)

### DIFF
--- a/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Controller\Ajax;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\SlugSuggesterService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Backend AJAX endpoint for the "Suggest slug" wizard.
+ *
+ * Route: GET/POST /typo3/ajax/ai-editorial-helper/slug?pageUid=123
+ *   or:  /typo3/ajax/ai-editorial-helper/slug?title=Something  (for new pages without a UID yet)
+ */
+final class SlugSuggesterAjaxController
+{
+    public function __construct(
+        private readonly SlugSuggesterService $service,
+        private readonly ConnectionPool $connectionPool,
+    ) {
+    }
+
+    public function suggest(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getParsedBody() + $request->getQueryParams();
+        $pageUid = (int)($params['pageUid'] ?? 0);
+        $titleOverride = trim((string)($params['title'] ?? ''));
+
+        $title = '';
+        $body = '';
+
+        if ($pageUid > 0) {
+            $page = BackendUtility::getRecord('pages', $pageUid);
+            if (!is_array($page)) {
+                return $this->error(sprintf('Page %d not found.', $pageUid), 404);
+            }
+            $title = (string)($page['title'] ?? '');
+            $body = $this->loadPageBody($pageUid);
+        }
+
+        if ($titleOverride !== '') {
+            // The form-field value beats the persisted record — editors get
+            // suggestions for the title they're typing right now.
+            $title = $titleOverride;
+        }
+
+        if (trim($title) === '') {
+            return $this->error('No title available — type a page title first.', 400);
+        }
+
+        try {
+            $slug = $this->service->generate($title, $body);
+        } catch (LmStudioException $e) {
+            return $this->error($this->humanizeException($e), 502);
+        }
+
+        return new JsonResponse([
+            'success' => true,
+            'slug' => $slug,
+        ]);
+    }
+
+    private function loadPageBody(int $pageUid): string
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $rows = $qb
+            ->select('header', 'subheader', 'bodytext')
+            ->from('tt_content')
+            ->where(
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->setMaxResults(20)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $parts = [];
+        foreach ($rows as $row) {
+            foreach (['header', 'subheader', 'bodytext'] as $field) {
+                $value = trim((string)($row[$field] ?? ''));
+                if ($value !== '') {
+                    $parts[] = $value;
+                }
+            }
+        }
+        return implode("\n\n", $parts);
+    }
+
+    private function humanizeException(LmStudioException $e): string
+    {
+        return match ($e->getCode()) {
+            LmStudioException::CODE_UNREACHABLE
+                => 'LM Studio is not reachable. Start LM Studio and load the configured model, then retry.',
+            LmStudioException::CODE_NO_MODEL_LOADED
+                => 'No model is loaded in LM Studio. Load the configured model in the LM Studio UI and retry.',
+            LmStudioException::CODE_INVALID_RESPONSE
+                => 'The model returned an unusable slug. Try again, or switch to a more capable model.',
+            default => 'LM Studio request failed: ' . $e->getMessage(),
+        };
+    }
+
+    private function error(string $message, int $status): ResponseInterface
+    {
+        return new JsonResponse(
+            ['success' => false, 'error' => $message],
+            $status,
+        );
+    }
+}

--- a/Classes/Form/FieldWizard/SuggestSlugWizard.php
+++ b/Classes/Form/FieldWizard/SuggestSlugWizard.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Form\FieldWizard;
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
+
+/**
+ * Renders a "Suggest slug" button next to the slug field on the
+ * pages-edit form. The button calls the AJAX endpoint registered by
+ * {@see \Kairos\AiEditorialHelper\Configuration\Backend\AjaxRoutes}.
+ *
+ * Unlike the meta-description wizard, this one shows up for new (uid=0)
+ * pages too — the editor can suggest a slug from a freshly typed title
+ * before the page has been saved.
+ */
+final class SuggestSlugWizard extends AbstractNode
+{
+    public function render(): array
+    {
+        $row = $this->data['databaseRow'] ?? [];
+        $pageUid = (int)($row['uid'] ?? 0);
+        $fieldName = (string)($this->data['fieldName'] ?? 'slug');
+
+        $buttonId = sprintf(
+            'ai-editorial-helper-slug-%d-%s',
+            $pageUid,
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+        );
+
+        $html = sprintf(
+            '<div class="form-wizards-element">'
+            . '<button type="button" class="btn btn-default ai-editorial-helper-suggest-slug" '
+            . 'id="%s" data-page-uid="%d" data-field="%s">'
+            . '<span class="t3js-icon icon icon-size-small">✨</span> %s'
+            . '</button>'
+            . '</div>',
+            $buttonId,
+            $pageUid,
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($this->translate('wizard.suggest_slug'), ENT_QUOTES, 'UTF-8'),
+        );
+
+        return [
+            'iconIdentifier' => null,
+            'html' => $html,
+            'javaScriptModules' => [
+                JavaScriptModuleInstruction::create('@kairos/ai-editorial-helper/slug-suggester-wizard.js'),
+            ],
+            'stylesheetFiles' => [],
+            'requireJsModules' => [],
+            'additionalHiddenFields' => [],
+            'additionalInlineLanguageLabelFiles' => [],
+            'inlineData' => [],
+        ];
+    }
+
+    private function translate(string $key): string
+    {
+        $lang = $GLOBALS['LANG'] ?? null;
+        if ($lang !== null && method_exists($lang, 'sL')) {
+            $label = $lang->sL('LLL:EXT:ai_editorial_helper/Resources/Private/Language/locallang_be.xlf:' . $key);
+            if (is_string($label) && $label !== '') {
+                return $label;
+            }
+        }
+        return 'Suggest slug';
+    }
+}

--- a/Classes/Service/PageSlugSanitizer.php
+++ b/Classes/Service/PageSlugSanitizer.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use TYPO3\CMS\Core\DataHandling\SlugHelper;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Pipes a slug candidate through TYPO3's SlugHelper for the pages.slug field
+ * and enforces a length cap with word-boundary backoff.
+ *
+ * Always run LLM-suggested slugs through this — the LLM might emit unicode
+ * punctuation, emoji, leading/trailing whitespace, or inconsistent casing.
+ * SlugHelper turns all of that into the canonical lowercase-hyphenated form
+ * that TYPO3 expects.
+ *
+ * Output for the pages.slug field is prefixed with "/" (TYPO3 convention).
+ * The length cap applies to the path component, not the leading slash.
+ */
+class PageSlugSanitizer
+{
+    public const DEFAULT_MAX_LENGTH = 60;
+    public const TABLE = 'pages';
+    public const FIELD = 'slug';
+
+    /**
+     * @param string $candidate Raw slug candidate (typically LLM output).
+     * @param int    $maxLength Maximum slug length excluding the leading "/".
+     */
+    public function sanitize(string $candidate, int $maxLength = self::DEFAULT_MAX_LENGTH): string
+    {
+        $sanitized = $this->sanitizeWithSlugHelper($candidate);
+
+        // SlugHelper for pages.slug always prepends "/" — work on the path only,
+        // then re-prepend.
+        $hasPrefix = str_starts_with($sanitized, '/');
+        $path = $hasPrefix ? substr($sanitized, 1) : $sanitized;
+
+        if ($maxLength > 0 && mb_strlen($path) > $maxLength) {
+            $path = $this->trimAtWordBoundary($path, $maxLength);
+        }
+
+        // Strip leading/trailing dashes left over from trimming or sanitization.
+        $path = trim($path, '-/');
+
+        if ($path === '') {
+            return '';
+        }
+
+        return $hasPrefix ? '/' . $path : $path;
+    }
+
+    /**
+     * Test seam: lets unit tests substitute a stub by overriding this method,
+     * without needing a fully-bootstrapped TYPO3 container.
+     */
+    protected function sanitizeWithSlugHelper(string $candidate): string
+    {
+        $tcaConfig = $GLOBALS['TCA'][self::TABLE]['columns'][self::FIELD]['config'] ?? [];
+        // SlugHelper requires at minimum a fallbackCharacter; default to "-".
+        $tcaConfig['fallbackCharacter'] = $tcaConfig['fallbackCharacter'] ?? '-';
+        $tcaConfig['generatorOptions'] = $tcaConfig['generatorOptions'] ?? [];
+
+        $helper = GeneralUtility::makeInstance(
+            SlugHelper::class,
+            self::TABLE,
+            self::FIELD,
+            $tcaConfig,
+        );
+        return $helper->sanitize($candidate);
+    }
+
+    private function trimAtWordBoundary(string $value, int $max): string
+    {
+        $cut = mb_substr($value, 0, $max);
+        $lastDash = mb_strrpos($cut, '-');
+        if ($lastDash !== false && $lastDash >= (int)($max * 0.5)) {
+            return mb_substr($cut, 0, $lastDash);
+        }
+        return $cut;
+    }
+}

--- a/Classes/Service/SlugSuggesterService.php
+++ b/Classes/Service/SlugSuggesterService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+
+/**
+ * Suggests an SEO-friendly URL slug for a TYPO3 page.
+ *
+ * Difference vs TYPO3 core's SlugHelper::generate():
+ *   - Core generates a *literal* slug from the title ("Über uns" → "ueber-uns").
+ *   - This service uses an LLM to produce a *semantic* slug, i.e. one that
+ *     captures the page's intent rather than transliterating its title
+ *     ("Über uns" → "/about" if site is multilingual; long article title
+ *     compressed to its essence).
+ *
+ * The LLM output is ALWAYS piped through {@see PageSlugSanitizer} — never
+ * trust the LLM to produce safe characters or honor the length cap.
+ */
+class SlugSuggesterService
+{
+    public const DEFAULT_MAX_LENGTH = 60;
+
+    private const SCHEMA_NAME = 'AiEditorialSlugResult';
+
+    private const SYSTEM_PROMPT = <<<TXT
+You are an SEO URL slug generator for a TYPO3 CMS.
+Given a page title and optional content, return a JSON object with one field:
+  - "slug": a concise, lowercase, hyphen-separated path segment.
+
+Rules:
+  - Capture the page's intent. A short verbose title can be condensed
+    (e.g. "The Complete Guide to Cycling for Absolute Beginners" → "cycling-guide").
+  - Prefer English when the source is German and the slug should be
+    multilingual-friendly; otherwise match the source language.
+  - Use only ASCII letters, digits, and hyphens. No spaces, no leading/
+    trailing hyphens, no slashes, no unicode characters.
+  - Keep it under 50 characters when possible.
+  - No file extensions, no query strings, no underscores.
+TXT;
+
+    public function __construct(
+        private readonly LmStudioClient $client,
+        private readonly PageSlugSanitizer $sanitizer,
+    ) {
+    }
+
+    /**
+     * @param string $title    Page title (required — empty title is rejected).
+     * @param string $content  Optional plain-text content for additional context.
+     * @param int    $maxLength Maximum slug length (excluding the leading "/").
+     *
+     * @throws LmStudioException When the LLM is unreachable or returns an empty/unusable slug.
+     */
+    public function generate(string $title, string $content = '', int $maxLength = self::DEFAULT_MAX_LENGTH): string
+    {
+        $cleanTitle = trim($title);
+        if ($cleanTitle === '') {
+            throw new LmStudioException(
+                'Cannot suggest a slug: page has no title.',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        $cleanContent = $this->extractText($content);
+        $userMessage = sprintf(
+            "PAGE TITLE: %s\n\nPAGE CONTENT:\n%s",
+            $cleanTitle,
+            $cleanContent !== '' ? $cleanContent : '(no body content)',
+        );
+
+        $payload = $this->client->chatJsonSchema(
+            [
+                ['role' => 'system', 'content' => self::SYSTEM_PROMPT],
+                ['role' => 'user', 'content' => $userMessage],
+            ],
+            self::SCHEMA_NAME,
+            [
+                'type' => 'object',
+                'properties' => [
+                    'slug' => [
+                        'type' => 'string',
+                        // Schema cap ≤ public cap so post-trim has room to back off
+                        // to a hyphen boundary if the model lands mid-segment.
+                        'maxLength' => max(10, $maxLength - 5),
+                        'pattern' => '^[a-z0-9-]+$',
+                    ],
+                ],
+                'required' => ['slug'],
+                'additionalProperties' => false,
+            ],
+            ['temperature' => 0.2],
+        );
+
+        $candidate = (string)($payload['slug'] ?? '');
+        $sanitized = $this->sanitizer->sanitize($candidate, $maxLength);
+
+        if (trim($sanitized, '/-') === '') {
+            throw new LmStudioException(
+                'LM Studio returned an unusable slug after sanitization.',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Strip HTML, decode entities, collapse whitespace, cap length so the prompt
+     * stays small. Slug suggestion only needs the gist of the content.
+     */
+    private function extractText(string $content): string
+    {
+        $stripped = strip_tags($content);
+        $decoded = html_entity_decode($stripped, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $collapsed = preg_replace('/\s+/u', ' ', $decoded) ?? '';
+        $trimmed = trim($collapsed);
+        if (mb_strlen($trimmed) > 4000) {
+            $trimmed = mb_substr($trimmed, 0, 4000);
+        }
+        return $trimmed;
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Kairos\AiEditorialHelper\Controller\Ajax\CategorySuggesterAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\MetaDescriptionAjaxController;
+use Kairos\AiEditorialHelper\Controller\Ajax\SlugSuggesterAjaxController;
 
 return [
     'ai_editorial_helper_meta' => [
@@ -13,5 +14,9 @@ return [
     'ai_editorial_helper_categories' => [
         'path' => '/ai-editorial-helper/categories',
         'target' => CategorySuggesterAjaxController::class . '::suggest',
+    ],
+    'ai_editorial_helper_slug' => [
+        'path' => '/ai-editorial-helper/slug',
+        'target' => SlugSuggesterAjaxController::class . '::suggest',
     ],
 ];

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 defined('TYPO3') or die();
 
-use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
-use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
-
+/*
+ * Wire AI Editorial Helper field wizards into the pages-edit form.
+ *
+ * This file modifies TCA only — node-registry registration lives in
+ * ext_localconf.php (see issue #11 for the explanation: TCA cache freezes
+ * the TCA array between requests, so $TYPO3_CONF_VARS side-effects from a
+ * TCA override file would be lost on every request after the first).
+ */
 (static function (): void {
     if (!isset($GLOBALS['TCA']['pages']['columns'])) {
         return;
@@ -41,15 +46,14 @@ use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
         );
     }
 
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140100] = [
-        'nodeName' => 'aiEditorialHelperGenerateMeta',
-        'priority' => 40,
-        'class' => GenerateMetaDescriptionWizard::class,
-    ];
-
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140103] = [
-        'nodeName' => 'aiEditorialHelperSuggestCategories',
-        'priority' => 40,
-        'class' => SuggestCategoriesWizard::class,
-    ];
+    if (isset($columns['slug']['config'])) {
+        $columns['slug']['config']['fieldWizard'] = array_merge(
+            $columns['slug']['config']['fieldWizard'] ?? [],
+            [
+                'aiEditorialHelperSuggestSlug' => [
+                    'renderType' => 'aiEditorialHelperSuggestSlug',
+                ],
+            ],
+        );
+    }
 })();

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -15,6 +15,15 @@
             <trans-unit id="notification.category_added">
                 <source>Category added. Save the page to persist.</source>
             </trans-unit>
+            <trans-unit id="wizard.suggest_slug">
+                <source>Suggest slug</source>
+            </trans-unit>
+            <trans-unit id="wizard.suggesting">
+                <source>Suggesting…</source>
+            </trans-unit>
+            <trans-unit id="notification.slug_applied">
+                <source>Slug suggestion applied. Review and save.</source>
+            </trans-unit>
             <trans-unit id="notification.title">
                 <source>AI Editorial Helper</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/slug-suggester-wizard.js
+++ b/Resources/Public/JavaScript/slug-suggester-wizard.js
@@ -1,0 +1,139 @@
+/**
+ * AI Editorial Helper — slug-suggester wizard.
+ *
+ * Mounted as an ES module by SuggestSlugWizard. Listens for clicks on
+ * `.ai-editorial-helper-suggest-slug` buttons inside the page-edit form,
+ * sends the current title (from the form, not the saved record) to the AJAX
+ * endpoint, and patches the returned slug back into the slug input.
+ */
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
+import Notification from "@typo3/backend/notification.js";
+
+const SELECTOR = ".ai-editorial-helper-suggest-slug";
+const BUSY_CLASS = "ai-editorial-helper-busy";
+
+function findInputForField(form, fieldName) {
+  if (!form) {
+    return null;
+  }
+  const escaped = fieldName.replace(/[\\"]/g, "\\$&");
+  return form.querySelector(`[data-formengine-input-name$="[${escaped}]"]`);
+}
+
+function readTitleFromForm(form) {
+  const input = findInputForField(form, "title");
+  if (input && input.value) {
+    return input.value.trim();
+  }
+  // nav_title is a reasonable fallback when title is empty.
+  const nav = findInputForField(form, "nav_title");
+  return nav && nav.value ? nav.value.trim() : "";
+}
+
+function syncHiddenCounterpart(input) {
+  const name = input.getAttribute("data-formengine-input-name");
+  if (!name) {
+    return;
+  }
+  const form = input.closest("form");
+  if (!form) {
+    return;
+  }
+  const hidden = form.querySelector(`input[type="hidden"][name="${CSS.escape(name)}"]`);
+  if (hidden && hidden !== input) {
+    hidden.value = input.value;
+  }
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  input.dispatchEvent(new Event("blur", { bubbles: true }));
+}
+
+function setSlug(form, fieldName, value) {
+  const input = findInputForField(form, fieldName);
+  if (!input) {
+    return false;
+  }
+  input.value = value;
+  syncHiddenCounterpart(input);
+  return true;
+}
+
+async function handleClick(event) {
+  const button = event.currentTarget;
+  if (button.classList.contains(BUSY_CLASS)) {
+    return;
+  }
+  const pageUid = parseInt(button.dataset.pageUid || "0", 10);
+  const fieldName = button.dataset.field || "slug";
+  const form = button.closest("form");
+  const title = readTitleFromForm(form);
+
+  if (!title && !pageUid) {
+    Notification.error(
+      "AI Editorial Helper",
+      "Type a page title first — there's nothing to derive a slug from yet.",
+    );
+    return;
+  }
+
+  button.classList.add(BUSY_CLASS);
+  button.disabled = true;
+  const originalText = button.textContent;
+  button.textContent = "Suggesting…";
+
+  try {
+    const args = {};
+    if (pageUid > 0) {
+      args.pageUid = pageUid;
+    }
+    if (title) {
+      args.title = title;
+    }
+    const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.ai_editorial_helper_slug)
+      .withQueryArguments(args)
+      .get();
+    const payload = await response.resolve();
+
+    if (!payload || payload.success !== true) {
+      throw new Error(payload && payload.error ? payload.error : "Unknown error");
+    }
+
+    if (setSlug(form, fieldName, payload.slug)) {
+      Notification.success("AI Editorial Helper", "Slug suggestion applied. Review and save.");
+    } else {
+      Notification.warning(
+        "AI Editorial Helper",
+        `Generated slug "${payload.slug}" but couldn't find the slug field.`,
+      );
+    }
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    Notification.error("AI Editorial Helper", message);
+  } finally {
+    button.classList.remove(BUSY_CLASS);
+    button.disabled = false;
+    button.textContent = originalText;
+  }
+}
+
+function bind(root) {
+  root.querySelectorAll(SELECTOR).forEach((button) => {
+    if (button.dataset.aiHelperBound === "1") {
+      return;
+    }
+    button.dataset.aiHelperBound = "1";
+    button.addEventListener("click", handleClick);
+  });
+}
+
+bind(document);
+
+const observer = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    mutation.addedNodes.forEach((node) => {
+      if (node instanceof HTMLElement) {
+        bind(node);
+      }
+    });
+  }
+});
+observer.observe(document.body, { childList: true, subtree: true });

--- a/Tests/Unit/Service/PageSlugSanitizerTest.php
+++ b/Tests/Unit/Service/PageSlugSanitizerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Service\PageSlugSanitizer;
+use PHPUnit\Framework\TestCase;
+
+final class PageSlugSanitizerTest extends TestCase
+{
+    public function testStripsEmojiAndSpecialCharsViaSanitizer(): void
+    {
+        $sanitizer = $this->makeSanitizer(static fn (string $candidate): string => '/'
+            . preg_replace('/[^a-z0-9]+/u', '-', mb_strtolower($candidate)));
+
+        $result = $sanitizer->sanitize('Hello 🎉 World!');
+        self::assertSame('/hello-world', $result);
+    }
+
+    public function testTrimsToMaxLengthAtHyphenBoundary(): void
+    {
+        // Stub mimics SlugHelper: returns "/<lower-hyphenated>" untouched.
+        $sanitizer = $this->makeSanitizer(static fn (string $c): string => '/' . str_replace(' ', '-', strtolower($c)));
+
+        $longTitle = 'cycling-tips-for-absolute-beginners-on-quiet-country-roads-of-bavaria';
+        $result = $sanitizer->sanitize($longTitle, 30);
+
+        self::assertLessThanOrEqual(31, mb_strlen($result)); // 30 + leading slash
+        self::assertStringStartsWith('/', $result);
+        // Hyphen-boundary trim: the result must end on a complete segment, never a trailing dash.
+        self::assertDoesNotMatchRegularExpression('/-$/', $result);
+        // The original last segment "bavaria" must be gone (not truncated mid-segment).
+        self::assertStringNotContainsString('bavar', $result);
+        // The result must be a prefix of the input (no creative reshaping by the trim).
+        self::assertStringStartsWith($result, '/' . $longTitle);
+    }
+
+    public function testRetainsLeadingSlashFromSlugHelper(): void
+    {
+        $sanitizer = $this->makeSanitizer(static fn (string $c): string => '/about-us');
+        self::assertSame('/about-us', $sanitizer->sanitize('About Us'));
+    }
+
+    public function testStripsTrailingHyphenAfterTrim(): void
+    {
+        $sanitizer = $this->makeSanitizer(static fn (string $c): string => '/foo-bar-baz-quux-quuux');
+
+        $result = $sanitizer->sanitize('whatever', 10);
+        // Whatever the trim produced, it must NOT end with a dash.
+        self::assertSame('-', '-'); // sanity
+        self::assertDoesNotMatchRegularExpression('/-$/', $result);
+        self::assertStringStartsWith('/', $result);
+    }
+
+    public function testReturnsEmptyWhenSanitizerProducesOnlyDelimiters(): void
+    {
+        $sanitizer = $this->makeSanitizer(static fn (string $c): string => '/---');
+        self::assertSame('', $sanitizer->sanitize('🎉🎉🎉'));
+    }
+
+    public function testHandlesAlreadyShortSlug(): void
+    {
+        $sanitizer = $this->makeSanitizer(static fn (string $c): string => '/about');
+        self::assertSame('/about', $sanitizer->sanitize('About', 60));
+    }
+
+    public function testTrimsPathOnlyNotPrefix(): void
+    {
+        $sanitizer = $this->makeSanitizer(static fn (string $c): string => '/' . str_repeat('a', 100));
+
+        $result = $sanitizer->sanitize('whatever', 10);
+
+        self::assertStringStartsWith('/', $result);
+        // The path should be ≤ 10 chars (the leading slash is not counted).
+        self::assertLessThanOrEqual(11, mb_strlen($result));
+    }
+
+    public function testHonorsNoCapWhenMaxLengthIsZero(): void
+    {
+        $sanitizer = $this->makeSanitizer(static fn (string $c): string => '/' . str_repeat('a', 200));
+        $result = $sanitizer->sanitize('whatever', 0);
+        self::assertSame(201, mb_strlen($result));
+    }
+
+    /**
+     * Build a PageSlugSanitizer subclass that delegates to the given closure
+     * instead of touching $GLOBALS['TCA'] / GeneralUtility.
+     */
+    private function makeSanitizer(\Closure $sanitizeFn): PageSlugSanitizer
+    {
+        return new class ($sanitizeFn) extends PageSlugSanitizer {
+            public function __construct(private readonly \Closure $fn)
+            {
+            }
+            protected function sanitizeWithSlugHelper(string $candidate): string
+            {
+                return ($this->fn)($candidate);
+            }
+        };
+    }
+}

--- a/Tests/Unit/Service/SlugSuggesterServiceTest.php
+++ b/Tests/Unit/Service/SlugSuggesterServiceTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+use Kairos\AiEditorialHelper\Service\PageSlugSanitizer;
+use Kairos\AiEditorialHelper\Service\SlugSuggesterService;
+use PHPUnit\Framework\TestCase;
+
+final class SlugSuggesterServiceTest extends TestCase
+{
+    public function testReturnsSanitizedSlug(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['slug' => 'cycling-guide']);
+
+        $sanitizer = $this->createMock(PageSlugSanitizer::class);
+        $sanitizer->expects(self::once())
+            ->method('sanitize')
+            ->with('cycling-guide', 60)
+            ->willReturn('/cycling-guide');
+
+        $service = new SlugSuggesterService($client, $sanitizer);
+        self::assertSame('/cycling-guide', $service->generate('Cycling for Beginners'));
+    }
+
+    public function testPassesCustomMaxLengthToSanitizer(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['slug' => 'short']);
+
+        $sanitizer = $this->createMock(PageSlugSanitizer::class);
+        $sanitizer->expects(self::once())
+            ->method('sanitize')
+            ->with('short', 30)
+            ->willReturn('/short');
+
+        $service = new SlugSuggesterService($client, $sanitizer);
+        $service->generate('Title', '', 30);
+    }
+
+    public function testEmojiInLlmOutputIsAlwaysSanitized(): void
+    {
+        // The LLM may break the schema regex pattern (it's a hint, not a hard constraint
+        // for many local models). The sanitizer is the LAST line of defense.
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['slug' => 'cycling 🚴 guide!']);
+
+        $sanitizer = $this->createMock(PageSlugSanitizer::class);
+        $sanitizer->expects(self::once())
+            ->method('sanitize')
+            ->with('cycling 🚴 guide!', 60)
+            ->willReturn('/cycling-guide');
+
+        $service = new SlugSuggesterService($client, $sanitizer);
+        self::assertSame('/cycling-guide', $service->generate('Cycling Guide'));
+    }
+
+    public function testIncludesContentInPromptWhenProvided(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(
+                self::callback(function (array $messages): bool {
+                    self::assertSame('system', $messages[0]['role']);
+                    self::assertStringContainsString('SEO URL slug generator', $messages[0]['content']);
+                    self::assertStringContainsString('Cycling Tips', $messages[1]['content']);
+                    self::assertStringContainsString('Bavaria countryside', $messages[1]['content']);
+                    self::assertStringNotContainsString('<', $messages[1]['content']);
+                    return true;
+                }),
+                self::equalTo('AiEditorialSlugResult'),
+                self::callback(function (array $schema): bool {
+                    self::assertSame('object', $schema['type']);
+                    self::assertContains('slug', $schema['required']);
+                    self::assertSame('string', $schema['properties']['slug']['type']);
+                    self::assertSame('^[a-z0-9-]+$', $schema['properties']['slug']['pattern']);
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn(['slug' => 'bavaria-cycling']);
+
+        $sanitizer = $this->createMock(PageSlugSanitizer::class);
+        $sanitizer->method('sanitize')->willReturnArgument(0);
+
+        $service = new SlugSuggesterService($client, $sanitizer);
+        $service->generate('Cycling Tips', '<p>Routes through the Bavaria countryside.</p>');
+    }
+
+    public function testThrowsOnEmptyTitle(): void
+    {
+        $service = new SlugSuggesterService(
+            $this->createMock(LmStudioClient::class),
+            $this->createMock(PageSlugSanitizer::class),
+        );
+
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_INVALID_RESPONSE);
+        $service->generate('   ');
+    }
+
+    public function testThrowsWhenSanitizedSlugIsEmpty(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['slug' => '🎉🎉🎉']);
+
+        $sanitizer = $this->createMock(PageSlugSanitizer::class);
+        $sanitizer->method('sanitize')->willReturn('');
+
+        $service = new SlugSuggesterService($client, $sanitizer);
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_INVALID_RESPONSE);
+        $service->generate('Title');
+    }
+
+    public function testThrowsWhenLlmReturnsOnlyDelimiters(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['slug' => '---']);
+
+        $sanitizer = $this->createMock(PageSlugSanitizer::class);
+        $sanitizer->method('sanitize')->willReturn('/---');
+
+        $service = new SlugSuggesterService($client, $sanitizer);
+        $this->expectException(LmStudioException::class);
+        $service->generate('Title');
+    }
+
+    public function testPropagatesUnreachableException(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willThrowException(
+            new LmStudioException('refused', LmStudioException::CODE_UNREACHABLE),
+        );
+
+        $service = new SlugSuggesterService(
+            $client,
+            $this->createMock(PageSlugSanitizer::class),
+        );
+
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_UNREACHABLE);
+        $service->generate('Title');
+    }
+
+    public function testSchemaCapIsBelowPublicMaxLength(): void
+    {
+        // Verify the schema's maxLength leaves headroom (at least 5 chars) for
+        // the sanitizer's word-boundary backoff. Regression from cycle 1 learning.
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::callback(function (array $schema): bool {
+                    $cap = $schema['properties']['slug']['maxLength'];
+                    self::assertSame(60 - 5, $cap, 'Schema cap must be public cap minus 5');
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn(['slug' => 'x']);
+
+        $sanitizer = $this->createMock(PageSlugSanitizer::class);
+        $sanitizer->method('sanitize')->willReturn('/x');
+
+        $service = new SlugSuggesterService($client, $sanitizer);
+        $service->generate('Title');
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,3 +1,43 @@
 <?php
 
+declare(strict_types=1);
+
 defined('TYPO3') or die();
+
+use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
+use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
+use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestSlugWizard;
+
+/*
+ * Register custom FormEngine field-wizard nodes.
+ *
+ * Why ext_localconf.php and NOT a TCA override file:
+ *
+ * TYPO3 caches the loaded TCA array between requests. The override files in
+ * Configuration/TCA/Overrides/*.php run ONCE when the cache is built — any
+ * side-effects beyond TCA mutation (e.g. writing to TYPO3_CONF_VARS) are lost
+ * on subsequent requests. ext_localconf.php is included on every request, so
+ * the nodeRegistry registration is always present when NodeFactory's
+ * constructor reads it.
+ *
+ * Symptom of getting this wrong: FormEngine renders the literal string
+ * "Unknown type: input, render type: aiEditorialHelperGenerateMeta" in place
+ * of the wizard button. (See issue #11.)
+ */
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140100] = [
+    'nodeName' => 'aiEditorialHelperGenerateMeta',
+    'priority' => 40,
+    'class' => GenerateMetaDescriptionWizard::class,
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140101] = [
+    'nodeName' => 'aiEditorialHelperSuggestSlug',
+    'priority' => 40,
+    'class' => SuggestSlugWizard::class,
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140103] = [
+    'nodeName' => 'aiEditorialHelperSuggestCategories',
+    'priority' => 40,
+    'class' => SuggestCategoriesWizard::class,
+];


### PR DESCRIPTION
Implements [#4](https://github.com/backant-io/typo3-ai-helper/issues/4). Builds on the LmStudioClient foundation merged in #7. (Replaces closed PR #9 — auto-closed when its stacked base branch was deleted on merge.)

## What's included

- **`Classes/Service/SlugSuggesterService.php`** — produces a semantic slug from a page title (+ optional content). Schema cap is 5 chars below the public 60-char cap so the sanitizer has headroom.
- **`Classes/Service/PageSlugSanitizer.php`** — last line of defense. Pipes the LLM candidate through TYPO3's `SlugHelper` and trims at hyphen boundaries. Strips trailing dashes; rejects all-delimiter results.
- **`Classes/Controller/Ajax/SlugSuggesterAjaxController.php`** + route — accepts `pageUid` and an optional `title` override (so unsaved pages can get a slug from a freshly typed title).
- **`Classes/Form/FieldWizard/SuggestSlugWizard.php`** + TCA override on `pages.slug`. Visible for new pages too (`uid=0`).
- **`Resources/Public/JavaScript/slug-suggester-wizard.js`** — reads the live title input, calls AJAX, patches the slug field.

## Why a sanitizer guard layer

The JSON Schema `pattern` is a hint to LM Studio, not a hard constraint. The sanitizer ALWAYS runs:

```
LLM candidate: "cycling 🚴 guide!" → PageSlugSanitizer → "/cycling-guide"
```

## Tests — 45 / 45 ✓

17 new tests across `PageSlugSanitizerTest` (emoji stripping, word-boundary trim, no-cap mode, path-only trim, all-delimiter rejection) and `SlugSuggesterServiceTest` (sanitizer-always-called, max-length propagation, empty rejections, schema-cap-headroom regression).

## Live integration check (qwen/qwen3-14b on LM Studio)

| Title | Slug |
|---|---|
| Cycling for Absolute Beginners on Quiet Country Roads | `/cycling-for-absolute-beginners-on-quiet-country-roads` |
| Über uns | `/uber-uns` |
| **The Complete Guide to TYPO3 Headless with Next.js** | **`/typo3-headless-nextjs-guide`** |
| Hello World 🎉 | `/hello-world` |

The third row is exactly the **semantic compression** the issue described.

## Acceptance-criteria checklist

- [x] `SlugSuggesterService.php` returns slug-safe string (lowercase, hyphens, no special chars).
- [x] Length cap (60 default, configurable per-call).
- [x] **Always sanitized through `SlugHelper::sanitize`** before returning.
- [x] Backend integration: *Suggest slug* button.
- [x] PHPUnit tests including emoji + special-character sanitization.
- [x] Out of scope: slug uniqueness, redirect creation.

Closes #4.