### PR TITLE
Add teaser / excerpt generator (#3)

### DIFF
--- a/Classes/Controller/Ajax/TeaserAjaxController.php
+++ b/Classes/Controller/Ajax/TeaserAjaxController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Controller\Ajax;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\TeaserService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Backend AJAX endpoint for the "Generate teaser" wizard.
+ *
+ * Route: GET/POST /typo3/ajax/ai-editorial-helper/teaser?pageUid=123
+ */
+final class TeaserAjaxController
+{
+    public function __construct(
+        private readonly TeaserService $service,
+        private readonly ConnectionPool $connectionPool,
+    ) {
+    }
+
+    public function generate(ServerRequestInterface $request): ResponseInterface
+    {
+        $params = $request->getParsedBody() + $request->getQueryParams();
+        $pageUid = (int)($params['pageUid'] ?? 0);
+
+        if ($pageUid <= 0) {
+            return $this->error('Missing or invalid pageUid parameter.', 400);
+        }
+
+        $page = BackendUtility::getRecord('pages', $pageUid);
+        if (!is_array($page)) {
+            return $this->error(sprintf('Page %d not found.', $pageUid), 404);
+        }
+
+        $title = (string)($page['title'] ?? '');
+        $body = $this->loadPageBody($pageUid);
+
+        try {
+            $teaser = $this->service->generate($title, $body);
+        } catch (LmStudioException $e) {
+            return $this->error($this->humanizeException($e), 502);
+        }
+
+        return new JsonResponse([
+            'success' => true,
+            'teaser' => $teaser,
+        ]);
+    }
+
+    private function loadPageBody(int $pageUid): string
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $rows = $qb
+            ->select('header', 'subheader', 'bodytext')
+            ->from('tt_content')
+            ->where(
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->setMaxResults(20)
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $parts = [];
+        foreach ($rows as $row) {
+            foreach (['header', 'subheader', 'bodytext'] as $field) {
+                $value = trim((string)($row[$field] ?? ''));
+                if ($value !== '') {
+                    $parts[] = $value;
+                }
+            }
+        }
+        return implode("\n\n", $parts);
+    }
+
+    private function humanizeException(LmStudioException $e): string
+    {
+        return match ($e->getCode()) {
+            LmStudioException::CODE_UNREACHABLE
+                => 'LM Studio is not reachable. Start LM Studio and load the configured model, then retry.',
+            LmStudioException::CODE_NO_MODEL_LOADED
+                => 'No model is loaded in LM Studio. Load the configured model in the LM Studio UI and retry.',
+            LmStudioException::CODE_INVALID_RESPONSE
+                => 'The model returned an unusable teaser. Try again, or switch to a more capable model.',
+            default => 'LM Studio request failed: ' . $e->getMessage(),
+        };
+    }
+
+    private function error(string $message, int $status): ResponseInterface
+    {
+        return new JsonResponse(
+            ['success' => false, 'error' => $message],
+            $status,
+        );
+    }
+}

--- a/Classes/Form/FieldWizard/GenerateTeaserWizard.php
+++ b/Classes/Form/FieldWizard/GenerateTeaserWizard.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Form\FieldWizard;
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
+
+/**
+ * Renders a "Generate teaser" button next to the abstract field on the
+ * pages-edit form. Hidden for new (uid<=0) pages because we need
+ * tt_content to derive a teaser from.
+ */
+final class GenerateTeaserWizard extends AbstractNode
+{
+    public function render(): array
+    {
+        $row = $this->data['databaseRow'] ?? [];
+        $pageUid = (int)($row['uid'] ?? 0);
+        $fieldName = (string)($this->data['fieldName'] ?? 'abstract');
+
+        if ($pageUid <= 0) {
+            return [
+                'iconIdentifier' => null,
+                'html' => '',
+                'javaScriptModules' => [],
+            ];
+        }
+
+        $buttonId = sprintf(
+            'ai-editorial-helper-teaser-%d-%s',
+            $pageUid,
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+        );
+
+        $html = sprintf(
+            '<div class="form-wizards-element">'
+            . '<button type="button" class="btn btn-default ai-editorial-helper-generate-teaser" '
+            . 'id="%s" data-page-uid="%d" data-field="%s">'
+            . '<span class="t3js-icon icon icon-size-small">✨</span> %s'
+            . '</button>'
+            . '</div>',
+            $buttonId,
+            $pageUid,
+            htmlspecialchars($fieldName, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($this->translate('wizard.generate_teaser'), ENT_QUOTES, 'UTF-8'),
+        );
+
+        return [
+            'iconIdentifier' => null,
+            'html' => $html,
+            'javaScriptModules' => [
+                JavaScriptModuleInstruction::create('@kairos/ai-editorial-helper/teaser-generator-wizard.js'),
+            ],
+            'stylesheetFiles' => [],
+            'requireJsModules' => [],
+            'additionalHiddenFields' => [],
+            'additionalInlineLanguageLabelFiles' => [],
+            'inlineData' => [],
+        ];
+    }
+
+    private function translate(string $key): string
+    {
+        $lang = $GLOBALS['LANG'] ?? null;
+        if ($lang !== null && method_exists($lang, 'sL')) {
+            $label = $lang->sL('LLL:EXT:ai_editorial_helper/Resources/Private/Language/locallang_be.xlf:' . $key);
+            if (is_string($label) && $label !== '') {
+                return $label;
+            }
+        }
+        return 'Generate teaser';
+    }
+}

--- a/Classes/Service/TeaserService.php
+++ b/Classes/Service/TeaserService.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+
+/**
+ * Generates a 1–2-sentence teaser for a TYPO3 page, intended for the
+ * pages.abstract field or any list-view rendering that needs a short blurb.
+ *
+ * Hard cap: 240 chars. Output ALWAYS ends on sentence-ending punctuation
+ * (`.`, `!`, `?`) — if the LLM produces a partial trailing sentence we
+ * trim back to the previous full one.
+ */
+class TeaserService
+{
+    public const MAX_LENGTH = 240;
+
+    private const SCHEMA_MAX = 235;
+    private const SCHEMA_NAME = 'AiEditorialTeaserResult';
+
+    private const SYSTEM_PROMPT = <<<TXT
+You are an editorial copywriter assisting an editor in a TYPO3 CMS.
+Given a page's title and body content, return a JSON object with one field:
+  - "teaser": a 1–2 sentence excerpt suitable for a list view or RSS feed.
+
+Rules:
+  - Match the language of the source content (German source → German teaser, English source → English teaser).
+  - Maximum 235 characters. Stay safely under the cap.
+  - Always end on a complete sentence — punctuation `.`, `!` or `?`.
+  - Do not invent facts. Stay faithful to the source.
+  - No leading/trailing quotes. No lead-in like "This page is about…".
+  - No markdown, no HTML.
+TXT;
+
+    public function __construct(
+        private readonly LmStudioClient $client,
+    ) {
+    }
+
+    /**
+     * @throws LmStudioException When LM Studio is unreachable or returns an unusable teaser.
+     */
+    public function generate(string $title, string $body): string
+    {
+        $cleanBody = $this->extractText($body);
+        $cleanTitle = trim($title);
+
+        if ($cleanBody === '' && $cleanTitle === '') {
+            throw new LmStudioException(
+                'Cannot generate a teaser: page has no title and no content.',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        $userMessage = sprintf(
+            "PAGE TITLE:\n%s\n\nPAGE CONTENT:\n%s",
+            $cleanTitle !== '' ? $cleanTitle : '(no title)',
+            $cleanBody !== '' ? $cleanBody : '(no body content)',
+        );
+
+        $payload = $this->client->chatJsonSchema(
+            [
+                ['role' => 'system', 'content' => self::SYSTEM_PROMPT],
+                ['role' => 'user', 'content' => $userMessage],
+            ],
+            self::SCHEMA_NAME,
+            [
+                'type' => 'object',
+                'properties' => [
+                    'teaser' => ['type' => 'string', 'maxLength' => self::SCHEMA_MAX],
+                ],
+                'required' => ['teaser'],
+                'additionalProperties' => false,
+            ],
+            ['temperature' => 0.4],
+        );
+
+        $teaser = $this->trimToCompleteSentence((string)($payload['teaser'] ?? ''));
+
+        if ($teaser === '') {
+            throw new LmStudioException(
+                'LM Studio returned an empty teaser.',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        return $teaser;
+    }
+
+    private function extractText(string $body): string
+    {
+        $stripped = strip_tags($body);
+        $decoded = html_entity_decode($stripped, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $collapsed = preg_replace('/\s+/u', ' ', $decoded) ?? '';
+        $trimmed = trim($collapsed);
+        if (mb_strlen($trimmed) > 8000) {
+            $trimmed = mb_substr($trimmed, 0, 8000);
+        }
+        return $trimmed;
+    }
+
+    /**
+     * Hard-cap at MAX_LENGTH and ensure the result ends on sentence-ending
+     * punctuation. Strategy:
+     *   1. Strip surrounding whitespace and quotes.
+     *   2. Hard-cut at MAX_LENGTH if needed.
+     *   3. If the result already ends on .!? — done.
+     *   4. Else find the last .!? within the (possibly truncated) string and
+     *      truncate after it, provided we keep at least 50% of the cap.
+     *   5. Otherwise back off to the last word boundary and append ".".
+     */
+    private function trimToCompleteSentence(string $value): string
+    {
+        $value = trim(preg_replace('/\s+/u', ' ', $value) ?? '');
+        $value = trim($value, "\"'“”‘’");
+        if ($value === '') {
+            return '';
+        }
+
+        if (mb_strlen($value) > self::MAX_LENGTH) {
+            $value = mb_substr($value, 0, self::MAX_LENGTH);
+        }
+
+        if ($this->endsOnSentenceEnd($value)) {
+            return $value;
+        }
+
+        // Find the last sentence-ending punctuation in the (truncated) string.
+        $lastEnd = $this->lastSentenceEndPosition($value);
+        if ($lastEnd !== null && $lastEnd >= (int)(self::MAX_LENGTH * 0.5)) {
+            return mb_substr($value, 0, $lastEnd + 1);
+        }
+
+        // No usable sentence ending — back off to a word boundary and append a period.
+        $lastSpace = mb_strrpos($value, ' ');
+        if ($lastSpace !== false && $lastSpace >= (int)(self::MAX_LENGTH * 0.5)) {
+            $value = mb_substr($value, 0, $lastSpace);
+        }
+        $value = rtrim($value, " \t\n\r\0\x0B,;:-—–|");
+        if ($value === '') {
+            return '';
+        }
+
+        return $value . '.';
+    }
+
+    private function endsOnSentenceEnd(string $value): bool
+    {
+        $last = mb_substr($value, -1);
+        return $last === '.' || $last === '!' || $last === '?' || $last === '…';
+    }
+
+    private function lastSentenceEndPosition(string $value): ?int
+    {
+        // Iterate from the end, return position of the latest .!?
+        $length = mb_strlen($value);
+        for ($i = $length - 1; $i >= 0; $i--) {
+            $char = mb_substr($value, $i, 1);
+            if ($char === '.' || $char === '!' || $char === '?' || $char === '…') {
+                return $i;
+            }
+        }
+        return null;
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Kairos\AiEditorialHelper\Controller\Ajax\CategorySuggesterAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\MetaDescriptionAjaxController;
+use Kairos\AiEditorialHelper\Controller\Ajax\TeaserAjaxController;
 
 return [
     'ai_editorial_helper_meta' => [
@@ -13,5 +14,9 @@ return [
     'ai_editorial_helper_categories' => [
         'path' => '/ai-editorial-helper/categories',
         'target' => CategorySuggesterAjaxController::class . '::suggest',
+    ],
+    'ai_editorial_helper_teaser' => [
+        'path' => '/ai-editorial-helper/teaser',
+        'target' => TeaserAjaxController::class . '::generate',
     ],
 ];

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 defined('TYPO3') or die();
 
-use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
-use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
-
+/*
+ * Wire AI Editorial Helper field wizards into the pages-edit form.
+ *
+ * This file modifies TCA only — node-registry registration lives in
+ * ext_localconf.php (see issue #11 for the explanation: TCA cache freezes
+ * the TCA array between requests, so $TYPO3_CONF_VARS side-effects from a
+ * TCA override file would be lost on every request after the first).
+ */
 (static function (): void {
     if (!isset($GLOBALS['TCA']['pages']['columns'])) {
         return;
@@ -41,15 +46,14 @@ use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
         );
     }
 
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140100] = [
-        'nodeName' => 'aiEditorialHelperGenerateMeta',
-        'priority' => 40,
-        'class' => GenerateMetaDescriptionWizard::class,
-    ];
-
-    $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140103] = [
-        'nodeName' => 'aiEditorialHelperSuggestCategories',
-        'priority' => 40,
-        'class' => SuggestCategoriesWizard::class,
-    ];
+    if (isset($columns['abstract']['config'])) {
+        $columns['abstract']['config']['fieldWizard'] = array_merge(
+            $columns['abstract']['config']['fieldWizard'] ?? [],
+            [
+                'aiEditorialHelperGenerateTeaser' => [
+                    'renderType' => 'aiEditorialHelperGenerateTeaser',
+                ],
+            ],
+        );
+    }
 })();

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -15,6 +15,12 @@
             <trans-unit id="notification.category_added">
                 <source>Category added. Save the page to persist.</source>
             </trans-unit>
+            <trans-unit id="wizard.generate_teaser">
+                <source>Generate teaser</source>
+            </trans-unit>
+            <trans-unit id="notification.teaser_applied">
+                <source>Teaser generated. Review and save.</source>
+            </trans-unit>
             <trans-unit id="notification.title">
                 <source>AI Editorial Helper</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/teaser-generator-wizard.js
+++ b/Resources/Public/JavaScript/teaser-generator-wizard.js
@@ -1,0 +1,117 @@
+/**
+ * AI Editorial Helper — teaser-generator wizard.
+ *
+ * Mounted as an ES module by GenerateTeaserWizard. Listens for clicks on
+ * `.ai-editorial-helper-generate-teaser` buttons inside the page-edit form,
+ * calls the AJAX endpoint, and patches the result into the abstract field.
+ */
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
+import Notification from "@typo3/backend/notification.js";
+
+const SELECTOR = ".ai-editorial-helper-generate-teaser";
+const BUSY_CLASS = "ai-editorial-helper-busy";
+
+function findInputForField(form, fieldName) {
+  if (!form) {
+    return null;
+  }
+  const escaped = fieldName.replace(/[\\"]/g, "\\$&");
+  // abstract is a textarea — match both input and textarea selectors.
+  return form.querySelector(`[data-formengine-input-name$="[${escaped}]"]`);
+}
+
+function syncHiddenCounterpart(input) {
+  const name = input.getAttribute("data-formengine-input-name");
+  if (!name) {
+    return;
+  }
+  const form = input.closest("form");
+  if (!form) {
+    return;
+  }
+  const hidden = form.querySelector(`[type="hidden"][name="${CSS.escape(name)}"]`);
+  if (hidden && hidden !== input) {
+    hidden.value = input.value;
+  }
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  input.dispatchEvent(new Event("blur", { bubbles: true }));
+}
+
+function setFieldValue(form, fieldName, value) {
+  const input = findInputForField(form, fieldName);
+  if (!input) {
+    return false;
+  }
+  input.value = value;
+  syncHiddenCounterpart(input);
+  return true;
+}
+
+async function handleClick(event) {
+  const button = event.currentTarget;
+  if (button.classList.contains(BUSY_CLASS)) {
+    return;
+  }
+  const pageUid = parseInt(button.dataset.pageUid || "0", 10);
+  const fieldName = button.dataset.field || "abstract";
+  if (!pageUid) {
+    Notification.error("AI Editorial Helper", "No page UID — save the page first.");
+    return;
+  }
+
+  const form = button.closest("form");
+  button.classList.add(BUSY_CLASS);
+  button.disabled = true;
+  const originalText = button.textContent;
+  button.textContent = "Generating…";
+
+  try {
+    const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.ai_editorial_helper_teaser)
+      .withQueryArguments({ pageUid })
+      .get();
+    const payload = await response.resolve();
+
+    if (!payload || payload.success !== true) {
+      throw new Error(payload && payload.error ? payload.error : "Unknown error");
+    }
+
+    if (setFieldValue(form, fieldName, payload.teaser)) {
+      Notification.success("AI Editorial Helper", "Teaser generated. Review and save.");
+    } else {
+      Notification.warning(
+        "AI Editorial Helper",
+        `Generated teaser but couldn't find the ${fieldName} field on this form.`,
+      );
+    }
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    Notification.error("AI Editorial Helper", message);
+  } finally {
+    button.classList.remove(BUSY_CLASS);
+    button.disabled = false;
+    button.textContent = originalText;
+  }
+}
+
+function bind(root) {
+  root.querySelectorAll(SELECTOR).forEach((button) => {
+    if (button.dataset.aiHelperBound === "1") {
+      return;
+    }
+    button.dataset.aiHelperBound = "1";
+    button.addEventListener("click", handleClick);
+  });
+}
+
+bind(document);
+
+const observer = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    mutation.addedNodes.forEach((node) => {
+      if (node instanceof HTMLElement) {
+        bind(node);
+      }
+    });
+  }
+});
+observer.observe(document.body, { childList: true, subtree: true });

--- a/Tests/Unit/Service/TeaserServiceTest.php
+++ b/Tests/Unit/Service/TeaserServiceTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+use Kairos\AiEditorialHelper\Service\TeaserService;
+use PHPUnit\Framework\TestCase;
+
+final class TeaserServiceTest extends TestCase
+{
+    public function testReturnsLlmTeaserWhenItAlreadyEndsOnPunctuation(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'teaser' => '  A friendly guide to your first 100 km on two wheels. Includes gear, route planning, and rain prep. ',
+        ]);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Cycling', 'body');
+
+        self::assertSame(
+            'A friendly guide to your first 100 km on two wheels. Includes gear, route planning, and rain prep.',
+            $result,
+        );
+    }
+
+    public function testEnforcesMaxLengthCap(): void
+    {
+        $longTeaser = str_repeat('Lorem ipsum dolor sit amet, consectetur adipiscing elit. ', 10);
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['teaser' => $longTeaser]);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Title', 'body');
+
+        self::assertLessThanOrEqual(TeaserService::MAX_LENGTH, mb_strlen($result));
+        self::assertNotEmpty($result);
+    }
+
+    public function testTrimsBackToLastSentenceEndWhenLongerThanCap(): void
+    {
+        $teaser = 'First sentence here. Second sentence is a bit longer to push us past the cap, '
+            . 'and we keep adding words and adding words and adding words and adding words until '
+            . 'we definitely exceed two hundred and forty characters because the test needs that, here we go more text more.';
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['teaser' => $teaser]);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Title', 'body');
+
+        self::assertLessThanOrEqual(TeaserService::MAX_LENGTH, mb_strlen($result));
+        // Must end on a sentence-ending punctuation.
+        self::assertMatchesRegularExpression('/[.!?…]$/u', $result);
+    }
+
+    public function testAppendsPeriodWhenNoSentenceEndExists(): void
+    {
+        // LLM emitted a no-punctuation snippet at the cap.
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'teaser' => str_repeat('a-word-that-keeps-going ', 12),
+        ]);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Title', 'body');
+
+        self::assertLessThanOrEqual(TeaserService::MAX_LENGTH, mb_strlen($result));
+        self::assertStringEndsWith('.', $result);
+    }
+
+    public function testStripsWrappingQuotes(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['teaser' => '"Quoted teaser content here."']);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Title', 'body');
+
+        self::assertSame('Quoted teaser content here.', $result);
+    }
+
+    public function testStripsHtmlAndCollapsesWhitespaceInBody(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(
+                self::callback(function (array $messages): bool {
+                    self::assertSame('system', $messages[0]['role']);
+                    self::assertStringContainsString('editorial copywriter', $messages[0]['content']);
+
+                    $userMsg = $messages[1]['content'];
+                    self::assertStringNotContainsString('<', $userMsg);
+                    self::assertStringContainsString('Hello world.', $userMsg);
+                    self::assertDoesNotMatchRegularExpression('/  +/', $userMsg);
+                    return true;
+                }),
+                self::equalTo('AiEditorialTeaserResult'),
+                self::callback(function (array $schema): bool {
+                    self::assertSame('object', $schema['type']);
+                    self::assertContains('teaser', $schema['required']);
+                    self::assertSame(235, $schema['properties']['teaser']['maxLength']);
+                    self::assertFalse($schema['additionalProperties']);
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn(['teaser' => 'A short teaser.']);
+
+        $service = new TeaserService($client);
+        $service->generate('Title', "<p>Hello   world.</p>\n<strong>More</strong>");
+    }
+
+    public function testThrowsOnEmptyTitleAndEmptyBody(): void
+    {
+        $service = new TeaserService($this->createMock(LmStudioClient::class));
+
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_INVALID_RESPONSE);
+        $service->generate('   ', '<p>   </p>');
+    }
+
+    public function testThrowsWhenLlmReturnsEmptyTeaser(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['teaser' => '   ']);
+
+        $service = new TeaserService($client);
+        $this->expectException(LmStudioException::class);
+        $service->generate('Title', 'body');
+    }
+
+    public function testPropagatesUnreachableException(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willThrowException(
+            new LmStudioException('refused', LmStudioException::CODE_UNREACHABLE),
+        );
+
+        $service = new TeaserService($client);
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_UNREACHABLE);
+        $service->generate('Title', 'Body content here.');
+    }
+
+    public function testGermanContentEndsOnGermanPunctuation(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'teaser' => 'Eine Berliner Digitalagentur mit Fokus auf TYPO3 und Barrierefreiheit. Seit 2012 im DACH-Raum aktiv.',
+        ]);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Über uns', 'Geschäftsbericht 2025.');
+
+        self::assertStringEndsWith('.', $result);
+        self::assertStringContainsString('Berliner Digitalagentur', $result);
+    }
+
+    public function testEllipsisCountsAsSentenceEnd(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'teaser' => 'A pondering thought…',
+        ]);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Title', 'body');
+
+        self::assertStringEndsWith('…', $result);
+    }
+
+    public function testRetainsExclamationAndQuestionMarks(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'teaser' => 'What is TYPO3 v13? A modern enterprise CMS!',
+        ]);
+
+        $service = new TeaserService($client);
+        $result = $service->generate('Title', 'body');
+
+        self::assertStringEndsWith('!', $result);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,3 +1,43 @@
 <?php
 
+declare(strict_types=1);
+
 defined('TYPO3') or die();
+
+use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
+use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateTeaserWizard;
+use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
+
+/*
+ * Register custom FormEngine field-wizard nodes.
+ *
+ * Why ext_localconf.php and NOT a TCA override file:
+ *
+ * TYPO3 caches the loaded TCA array between requests. The override files in
+ * Configuration/TCA/Overrides/*.php run ONCE when the cache is built — any
+ * side-effects beyond TCA mutation (e.g. writing to TYPO3_CONF_VARS) are lost
+ * on subsequent requests. ext_localconf.php is included on every request, so
+ * the nodeRegistry registration is always present when NodeFactory's
+ * constructor reads it.
+ *
+ * Symptom of getting this wrong: FormEngine renders the literal string
+ * "Unknown type: input, render type: aiEditorialHelperGenerateMeta" in place
+ * of the wizard button. (See issue #11.)
+ */
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140100] = [
+    'nodeName' => 'aiEditorialHelperGenerateMeta',
+    'priority' => 40,
+    'class' => GenerateMetaDescriptionWizard::class,
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140102] = [
+    'nodeName' => 'aiEditorialHelperGenerateTeaser',
+    'priority' => 40,
+    'class' => GenerateTeaserWizard::class,
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140103] = [
+    'nodeName' => 'aiEditorialHelperSuggestCategories',
+    'priority' => 40,
+    'class' => SuggestCategoriesWizard::class,
+];


### PR DESCRIPTION
Implements [#3](https://github.com/backant-io/typo3-ai-helper/issues/3). Builds on the LmStudioClient foundation merged in #7. (Replaces closed PR #10 — auto-closed when its stacked base branch was deleted on merge.)

## What's included

- **`Classes/Service/TeaserService.php`** — schema-bound JSON request returning `{ teaser: string }`. Schema cap 235 (5-char buffer below the public 240 cap). Three-tier sentence-aware post-trim:
  1. LLM ends on `.!?…` → keep as-is.
  2. Trimmed mid-sentence → back off to last `.!?…` if past 50% of the cap.
  3. No usable sentence end → back off to word boundary, strip dangling punctuation, append `.`.
- **`Classes/Controller/Ajax/TeaserAjaxController.php`** + route — parallel shape to existing controllers.
- **`Classes/Form/FieldWizard/GenerateTeaserWizard.php`** + TCA override on `pages.abstract.config.fieldWizard`.
- **`Resources/Public/JavaScript/teaser-generator-wizard.js`** — ES module that patches the abstract textarea on success.

## Tests — 40 / 40 ✓

12 new tests for `TeaserService`: clean pass-through, cap enforcement, mid-sentence trim-back, no-punctuation period-append, quote stripping, HTML stripping, ellipsis/exclamation/question recognition, German content, empty rejections, exception propagation.

## Live integration check (qwen/qwen3-14b on LM Studio)

| Title | Teaser | Length |
|---|---|---|
| Über uns | *Wir sind eine Berliner Digitalagentur mit Fokus auf TYPO3, Barrierefreiheit und Performance. Seit 2012 betreuen wir Kunden im DACH-Raum.* | 136 |
| Cycling for Beginners | *A friendly guide for beginners covering gear basics, route planning, fueling strategies and what to do in the rain.* | 115 |
| TYPO3 v13 Release Notes | *TYPO3 v13 introduces a redesigned backend, improved Site Sets, native dashboard widgets and under-the-hood improvements for performance and developer ergonomics.* | 161 |

All three end on `.`, all under 240 chars, all in source language.

## Acceptance-criteria checklist

- [x] `TeaserService.php` returns string ≤ 240 chars.
- [x] Source-language preservation (DE → DE, EN → EN).
- [x] Backend hook on page-properties `abstract` field.
- [x] PHPUnit tests with mocked LmStudioClient.
- [x] Trims trailing partial sentences. Output always ends on punctuation.

Closes #3.