### PR TITLE
Fix #19: handle GET requests + render server error messages in wizards

### DIFF
--- a/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
@@ -27,7 +27,9 @@ final class CategorySuggesterAjaxController
 
     public function suggest(ServerRequestInterface $request): ResponseInterface
     {
-        $params = $request->getParsedBody() + $request->getQueryParams();
+        // getParsedBody() is null for GET requests. Coalesce to avoid TypeError
+        // on the array merge below. (See issue #19.)
+        $params = ($request->getParsedBody() ?? []) + $request->getQueryParams();
         $pageUid = (int)($params['pageUid'] ?? 0);
 
         if ($pageUid <= 0) {

--- a/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
+++ b/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
@@ -29,7 +29,10 @@ final class MetaDescriptionAjaxController
 
     public function generate(ServerRequestInterface $request): ResponseInterface
     {
-        $params = $request->getParsedBody() + $request->getQueryParams();
+        // ServerRequestInterface::getParsedBody() returns null on GET requests
+        // (and on POST without a parseable body). PHP 8.x raises TypeError on
+        // null + array — so coalesce to [] before merging with query params.
+        $params = ($request->getParsedBody() ?? []) + $request->getQueryParams();
         $pageUid = (int)($params['pageUid'] ?? 0);
 
         if ($pageUid <= 0) {

--- a/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
@@ -28,7 +28,9 @@ final class SlugSuggesterAjaxController
 
     public function suggest(ServerRequestInterface $request): ResponseInterface
     {
-        $params = $request->getParsedBody() + $request->getQueryParams();
+        // getParsedBody() is null for GET requests. Coalesce to avoid TypeError
+        // on the array merge below. (See issue #19.)
+        $params = ($request->getParsedBody() ?? []) + $request->getQueryParams();
         $pageUid = (int)($params['pageUid'] ?? 0);
         $titleOverride = trim((string)($params['title'] ?? ''));
 

--- a/Classes/Controller/Ajax/TeaserAjaxController.php
+++ b/Classes/Controller/Ajax/TeaserAjaxController.php
@@ -27,7 +27,9 @@ final class TeaserAjaxController
 
     public function generate(ServerRequestInterface $request): ResponseInterface
     {
-        $params = $request->getParsedBody() + $request->getQueryParams();
+        // getParsedBody() is null for GET requests. Coalesce to avoid TypeError
+        // on the array merge below. (See issue #19.)
+        $params = ($request->getParsedBody() ?? []) + $request->getQueryParams();
         $pageUid = (int)($params['pageUid'] ?? 0);
 
         if ($pageUid <= 0) {

--- a/Resources/Public/JavaScript/ajax-error.js
+++ b/Resources/Public/JavaScript/ajax-error.js
@@ -1,0 +1,33 @@
+/**
+ * Shared error-message extractor for AI Editorial Helper wizards.
+ *
+ * Background (issue #19): TYPO3's AjaxRequest rejects with an AjaxResponse
+ * object on non-2xx, NOT a JS Error. Naively casting that to String produces
+ * "[object Object]". We need to dig out the JSON body the controller sent
+ * (`{ success: false, error: "human-readable message" }`) and surface that.
+ *
+ * @param {unknown} err  Whatever the catch block received.
+ * @returns {Promise<string>}  A user-presentable error message.
+ */
+export async function extractAjaxErrorMessage(err) {
+  if (err && typeof err === "object" && err.response && typeof err.response.resolve === "function") {
+    try {
+      const body = await err.response.resolve();
+      if (body && typeof body === "object" && typeof body.error === "string" && body.error.length > 0) {
+        return body.error;
+      }
+    } catch (_inner) {
+      // fall through to status text
+    }
+    if (err.response.statusText) {
+      return err.response.statusText;
+    }
+    if (typeof err.response.status === "number") {
+      return `HTTP ${err.response.status}`;
+    }
+  }
+  if (err && typeof err === "object" && typeof err.message === "string" && err.message.length > 0) {
+    return err.message;
+  }
+  return String(err ?? "Unknown error");
+}

--- a/Resources/Public/JavaScript/category-suggester-wizard.js
+++ b/Resources/Public/JavaScript/category-suggester-wizard.js
@@ -8,6 +8,7 @@
  */
 import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
 import Notification from "@typo3/backend/notification.js";
+import { extractAjaxErrorMessage } from "@kairos/ai-editorial-helper/ajax-error.js";
 
 const SELECTOR = ".ai-editorial-helper-suggest-categories";
 const BUSY_CLASS = "ai-editorial-helper-busy";
@@ -142,7 +143,7 @@ async function handleClick(event) {
     if (panel) {
       clearChildren(panel);
     }
-    const message = err && err.message ? err.message : String(err);
+    const message = await extractAjaxErrorMessage(err);
     Notification.error("AI Editorial Helper", message);
   } finally {
     button.classList.remove(BUSY_CLASS);

--- a/Resources/Public/JavaScript/meta-description-wizard.js
+++ b/Resources/Public/JavaScript/meta-description-wizard.js
@@ -8,6 +8,7 @@
  */
 import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
 import Notification from "@typo3/backend/notification.js";
+import { extractAjaxErrorMessage } from "@kairos/ai-editorial-helper/ajax-error.js";
 
 const SELECTOR = ".ai-editorial-helper-generate";
 const BUSY_CLASS = "ai-editorial-helper-busy";
@@ -89,7 +90,7 @@ async function handleClick(event) {
       Notification.success("AI Editorial Helper", "Meta description and SEO title generated. Review and save.");
     }
   } catch (err) {
-    const message = err && err.message ? err.message : String(err);
+    const message = await extractAjaxErrorMessage(err);
     Notification.error("AI Editorial Helper", message);
   } finally {
     button.classList.remove(BUSY_CLASS);

--- a/Resources/Public/JavaScript/slug-suggester-wizard.js
+++ b/Resources/Public/JavaScript/slug-suggester-wizard.js
@@ -8,6 +8,7 @@
  */
 import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
 import Notification from "@typo3/backend/notification.js";
+import { extractAjaxErrorMessage } from "@kairos/ai-editorial-helper/ajax-error.js";
 
 const SELECTOR = ".ai-editorial-helper-suggest-slug";
 const BUSY_CLASS = "ai-editorial-helper-busy";
@@ -106,7 +107,7 @@ async function handleClick(event) {
       );
     }
   } catch (err) {
-    const message = err && err.message ? err.message : String(err);
+    const message = await extractAjaxErrorMessage(err);
     Notification.error("AI Editorial Helper", message);
   } finally {
     button.classList.remove(BUSY_CLASS);

--- a/Resources/Public/JavaScript/teaser-generator-wizard.js
+++ b/Resources/Public/JavaScript/teaser-generator-wizard.js
@@ -7,6 +7,7 @@
  */
 import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
 import Notification from "@typo3/backend/notification.js";
+import { extractAjaxErrorMessage } from "@kairos/ai-editorial-helper/ajax-error.js";
 
 const SELECTOR = ".ai-editorial-helper-generate-teaser";
 const BUSY_CLASS = "ai-editorial-helper-busy";
@@ -84,7 +85,7 @@ async function handleClick(event) {
       );
     }
   } catch (err) {
-    const message = err && err.message ? err.message : String(err);
+    const message = await extractAjaxErrorMessage(err);
     Notification.error("AI Editorial Helper", message);
   } finally {
     button.classList.remove(BUSY_CLASS);

--- a/Tests/Unit/Controller/Ajax/AjaxControllersGetRequestTest.php
+++ b/Tests/Unit/Controller/Ajax/AjaxControllersGetRequestTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Controller\Ajax;
+
+use Kairos\AiEditorialHelper\Controller\Ajax\CategorySuggesterAjaxController;
+use Kairos\AiEditorialHelper\Controller\Ajax\MetaDescriptionAjaxController;
+use Kairos\AiEditorialHelper\Controller\Ajax\SlugSuggesterAjaxController;
+use Kairos\AiEditorialHelper\Controller\Ajax\TeaserAjaxController;
+use Kairos\AiEditorialHelper\Service\CategorySuggesterService;
+use Kairos\AiEditorialHelper\Service\MetaDescriptionService;
+use Kairos\AiEditorialHelper\Service\SlugSuggesterService;
+use Kairos\AiEditorialHelper\Service\TeaserService;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Regression for issue #19 (Bug A).
+ *
+ * Every AJAX controller used to do `$request->getParsedBody() + $request->getQueryParams()`.
+ * For GET requests `getParsedBody()` is null, and PHP 8.x raises TypeError on
+ * `null + array`. The controllers now coalesce with `?? []`. These tests
+ * exercise the GET path (no parsed body) on each controller and assert the
+ * response is a clean 400 (the controllers' own validation), not a 500
+ * caused by the TypeError.
+ *
+ * pageUid=0 deliberately triggers the early-return validation branch so we
+ * don't need to mock BackendUtility::getRecord (a static call).
+ */
+final class AjaxControllersGetRequestTest extends TestCase
+{
+    public function testMetaDescriptionControllerHandlesGetRequest(): void
+    {
+        $controller = new MetaDescriptionAjaxController(
+            $this->createMock(MetaDescriptionService::class),
+            $this->createMock(ConnectionPool::class),
+        );
+        $response = $controller->generate($this->getRequest());
+        self::assertSame(400, $response->getStatusCode());
+        self::assertStringContainsString('pageUid', (string)$response->getBody());
+    }
+
+    public function testSlugSuggesterControllerHandlesGetRequest(): void
+    {
+        $controller = new SlugSuggesterAjaxController(
+            $this->createMock(SlugSuggesterService::class),
+            $this->createMock(ConnectionPool::class),
+        );
+        // SlugSuggester accepts pageUid=0 if a title is given. Test the strict
+        // case: empty everything → expects an error response, not a TypeError.
+        $response = $controller->suggest($this->getRequest([]));
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    public function testTeaserControllerHandlesGetRequest(): void
+    {
+        $controller = new TeaserAjaxController(
+            $this->createMock(TeaserService::class),
+            $this->createMock(ConnectionPool::class),
+        );
+        $response = $controller->generate($this->getRequest());
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    public function testCategorySuggesterControllerHandlesGetRequest(): void
+    {
+        $controller = new CategorySuggesterAjaxController(
+            $this->createMock(CategorySuggesterService::class),
+            $this->createMock(ConnectionPool::class),
+        );
+        $response = $controller->suggest($this->getRequest());
+        self::assertSame(400, $response->getStatusCode());
+    }
+
+    public function testAllControllersAcceptNullParsedBodyWithoutTypeError(): void
+    {
+        // Belt-and-suspenders: the regression specifically asserts that a GET
+        // request (parsedBody=null) does NOT raise PHP's "null + array" TypeError.
+        // If the coalesce were ever removed, every assertion below would
+        // surface as an exception, not a status-code mismatch.
+        foreach ([
+            new MetaDescriptionAjaxController(
+                $this->createMock(MetaDescriptionService::class),
+                $this->createMock(ConnectionPool::class),
+            ),
+            new TeaserAjaxController(
+                $this->createMock(TeaserService::class),
+                $this->createMock(ConnectionPool::class),
+            ),
+            new CategorySuggesterAjaxController(
+                $this->createMock(CategorySuggesterService::class),
+                $this->createMock(ConnectionPool::class),
+            ),
+        ] as $controller) {
+            $method = method_exists($controller, 'generate') ? 'generate' : 'suggest';
+            $response = $controller->{$method}($this->getRequest(['pageUid' => 0]));
+            self::assertSame(
+                400,
+                $response->getStatusCode(),
+                sprintf('%s::%s did not return 400 on missing pageUid', $controller::class, $method),
+            );
+        }
+
+        $slugController = new SlugSuggesterAjaxController(
+            $this->createMock(SlugSuggesterService::class),
+            $this->createMock(ConnectionPool::class),
+        );
+        $slugResponse = $slugController->suggest($this->getRequest([]));
+        self::assertSame(400, $slugResponse->getStatusCode());
+    }
+
+    /**
+     * Build a GET-shaped ServerRequest: parsedBody is null (PSR-7 norm for GET),
+     * query params come from the array.
+     *
+     * @param array<string, mixed> $queryParams
+     */
+    private function getRequest(array $queryParams = ['pageUid' => 0]): ServerRequestInterface
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn(null);
+        $request->method('getQueryParams')->willReturn($queryParams);
+        return $request;
+    }
+}


### PR DESCRIPTION
Fixes [#19](https://github.com/backant-io/typo3-ai-helper/issues/19) — two stacked demo-blocker bugs that affected ALL four AJAX wizards (meta, slug, teaser, categories).

## Bug A — TypeError on GET requests

Every controller did:

```php
$params = $request->getParsedBody() + $request->getQueryParams();
```

For GET requests `getParsedBody()` is `null`. PHP 8.x raises `TypeError: Unsupported operand types: null + array` **before any actual logic runs**. Every wizard click hit a 500.

**Fix** (one-line, in 4 controllers):

```php
$params = ($request->getParsedBody() ?? []) + $request->getQueryParams();
```

**Regression test** — `Tests/Unit/Controller/Ajax/AjaxControllersGetRequestTest.php`: exercises a GET-shaped `ServerRequest` (parsedBody=null) on every controller. Asserts a clean 400 from the controller's own pageUid validation, **not** a 500 from the TypeError. 5 tests, 9 assertions, covers all 4 controllers.

## Bug B — Frontend rendered `[object Object]`

TYPO3's `AjaxRequest` rejects with an `AjaxResponse` object (not a JS `Error`) on non-2xx. The old catch was:

```js
const message = err && err.message ? err.message : String(err);
```

— which fell through to `String(err)` → `[object Object]`, hiding the perfectly readable error string the controller put in the JSON body.

**Fix**: extracted `extractAjaxErrorMessage(err)` into a shared module `Resources/Public/JavaScript/ajax-error.js`. All 4 wizards now do:

```js
} catch (err) {
  const message = await extractAjaxErrorMessage(err);
  Notification.error("AI Editorial Helper", message);
}
```

The helper digs into `err.response.resolve()` to surface the controller's `error` field, falls back to `statusText`, then the HTTP status, then `err.message`. The shared helper avoids fixing the same bug four times.

## Files changed

| File | Change |
|---|---|
| `Classes/Controller/Ajax/MetaDescriptionAjaxController.php` | `?? []` coalesce |
| `Classes/Controller/Ajax/SlugSuggesterAjaxController.php` | `?? []` coalesce |
| `Classes/Controller/Ajax/TeaserAjaxController.php` | `?? []` coalesce |
| `Classes/Controller/Ajax/CategorySuggesterAjaxController.php` | `?? []` coalesce |
| `Resources/Public/JavaScript/ajax-error.js` | **new** — shared helper |
| `Resources/Public/JavaScript/meta-description-wizard.js` | use helper |
| `Resources/Public/JavaScript/slug-suggester-wizard.js` | use helper |
| `Resources/Public/JavaScript/teaser-generator-wizard.js` | use helper |
| `Resources/Public/JavaScript/category-suggester-wizard.js` | use helper |
| `Tests/Unit/Controller/Ajax/AjaxControllersGetRequestTest.php` | **new** — 5 tests |

## Tests — 73 / 73 ✓

```
$ docker run --rm -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit -c Tests/UnitTests.xml
…
OK (73 tests, 198 assertions)
```

68 existing + 5 new regression tests.

## Acceptance from #19

- [x] All four AJAX controllers handle GET requests without TypeError. Unit test per controller for the GET path.
- [x] All four wizards render server-supplied error strings via `extractAjaxErrorMessage` (no more `[object Object]`).
- [x] Existing PHPUnit tests still pass (68 → 73, all green).
- [ ] Manual verification in the DDEV demo instance — for the human reviewer to confirm.

Closes #19.