### PR TITLE
Add DE↔EN translation stub (#5) — signature demo feature

### DIFF
--- a/Classes/Controller/Ajax/TranslationStubAjaxController.php
+++ b/Classes/Controller/Ajax/TranslationStubAjaxController.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Controller\Ajax;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\TranslationStubService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Http\JsonResponse;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Backend AJAX endpoint for the "Generate translation stub" wizard.
+ *
+ * Route: GET/POST /typo3/ajax/ai-editorial-helper/translate
+ *
+ * Inputs:
+ *   - contentUid (int, required): the tt_content row currently being edited.
+ *   - targetLang (string, optional): "de" or "en". When omitted, the controller
+ *     resolves the row's sys_language_uid via the site config.
+ *
+ * The controller looks up the source row via tt_content.l10n_source. If
+ * l10n_source is 0 (the row is the original), we refuse — there's nothing
+ * to translate from.
+ */
+final class TranslationStubAjaxController
+{
+    private const VALID_LANGS = ['de', 'en'];
+
+    public function __construct(
+        private readonly TranslationStubService $service,
+    ) {
+    }
+
+    public function generate(ServerRequestInterface $request): ResponseInterface
+    {
+        // PSR-7: getParsedBody() is null for GET requests — coalesce.
+        $params = ($request->getParsedBody() ?? []) + $request->getQueryParams();
+        $contentUid = (int)($params['contentUid'] ?? 0);
+        $targetOverride = strtolower(trim((string)($params['targetLang'] ?? '')));
+        $sourceOverride = strtolower(trim((string)($params['sourceLang'] ?? '')));
+
+        if ($contentUid <= 0) {
+            return $this->error('Missing or invalid contentUid parameter.', 400);
+        }
+
+        $row = BackendUtility::getRecord('tt_content', $contentUid);
+        if (!is_array($row)) {
+            return $this->error(sprintf('tt_content row %d not found.', $contentUid), 404);
+        }
+
+        $sourceUid = (int)($row['l10n_source'] ?? 0);
+        if ($sourceUid <= 0) {
+            return $this->error(
+                'This row has no source record (l10n_source=0). Translation stubs only apply to localised rows.',
+                400,
+            );
+        }
+
+        $sourceRow = BackendUtility::getRecord('tt_content', $sourceUid);
+        if (!is_array($sourceRow)) {
+            return $this->error(sprintf('Source row %d not found.', $sourceUid), 404);
+        }
+
+        $sourceBody = (string)($sourceRow['bodytext'] ?? '');
+        if (trim($sourceBody) === '') {
+            return $this->error('Source row has no bodytext to translate.', 400);
+        }
+
+        try {
+            $sourceLang = $sourceOverride !== ''
+                ? $sourceOverride
+                : $this->resolveLanguageCode((int)($sourceRow['pid'] ?? 0), (int)($sourceRow['sys_language_uid'] ?? 0));
+            $targetLang = $targetOverride !== ''
+                ? $targetOverride
+                : $this->resolveLanguageCode((int)($row['pid'] ?? 0), (int)($row['sys_language_uid'] ?? 0));
+        } catch (\Throwable $e) {
+            return $this->error('Cannot determine language pair: ' . $e->getMessage(), 400);
+        }
+
+        if (!in_array($sourceLang, self::VALID_LANGS, true)) {
+            return $this->error(sprintf('Unsupported source language "%s". Supported: %s.', $sourceLang, implode(', ', self::VALID_LANGS)), 400);
+        }
+        if (!in_array($targetLang, self::VALID_LANGS, true)) {
+            return $this->error(sprintf('Unsupported target language "%s". Supported: %s.', $targetLang, implode(', ', self::VALID_LANGS)), 400);
+        }
+
+        try {
+            $translated = $this->service->translate($sourceBody, $sourceLang, $targetLang);
+        } catch (LmStudioException $e) {
+            return $this->error($this->humanizeException($e), 502);
+        }
+
+        return new JsonResponse([
+            'success' => true,
+            'translation' => $translated,
+            'sourceLang' => $sourceLang,
+            'targetLang' => $targetLang,
+        ]);
+    }
+
+    /**
+     * Resolve the two-letter language code for a given page UID + sys_language_uid.
+     *
+     * Falls back to "en" for sys_language_uid=0 if no site config is present.
+     */
+    private function resolveLanguageCode(int $pageUid, int $sysLanguageUid): string
+    {
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+        try {
+            $site = $siteFinder->getSiteByPageId($pageUid);
+            $language = $site->getLanguageById($sysLanguageUid);
+            $tag = $language->getLocale()?->getLanguageCode() ?? $language->getTwoLetterIsoCode();
+            return strtolower((string)$tag);
+        } catch (\Throwable) {
+            // No site config / unknown page. Fall back: assume default-language is English.
+            return $sysLanguageUid === 0 ? 'en' : 'en';
+        }
+    }
+
+    private function humanizeException(LmStudioException $e): string
+    {
+        return match ($e->getCode()) {
+            LmStudioException::CODE_UNREACHABLE
+                => 'LM Studio is not reachable. Start LM Studio and load the configured model, then retry.',
+            LmStudioException::CODE_NO_MODEL_LOADED
+                => 'No model is loaded in LM Studio. Load the configured model in the LM Studio UI and retry.',
+            LmStudioException::CODE_INVALID_RESPONSE
+                => 'The model returned an unusable translation. Try again, or switch to a more capable model.',
+            default => 'LM Studio request failed: ' . $e->getMessage(),
+        };
+    }
+
+    private function error(string $message, int $status): ResponseInterface
+    {
+        return new JsonResponse(['success' => false, 'error' => $message], $status);
+    }
+}

--- a/Classes/Form/FieldWizard/GenerateTranslationStubWizard.php
+++ b/Classes/Form/FieldWizard/GenerateTranslationStubWizard.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Form\FieldWizard;
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
+
+/**
+ * Renders a "Generate translation stub" button next to the bodytext field on
+ * tt_content rows that are localizations of an original row (i.e. l10n_source > 0
+ * and sys_language_uid > 0). For original (default-language) rows, the button
+ * is hidden — there's nothing to translate from.
+ */
+final class GenerateTranslationStubWizard extends AbstractNode
+{
+    public function render(): array
+    {
+        $row = $this->data['databaseRow'] ?? [];
+        $contentUid = (int)($row['uid'] ?? 0);
+        $sysLanguageUid = (int)($row['sys_language_uid'] ?? 0);
+        $l10nSource = (int)($row['l10n_source'] ?? 0);
+
+        // Only show on localised rows that have a source to translate from.
+        if ($contentUid <= 0 || $sysLanguageUid === 0 || $l10nSource <= 0) {
+            return [
+                'iconIdentifier' => null,
+                'html' => '',
+                'javaScriptModules' => [],
+            ];
+        }
+
+        $buttonId = sprintf('ai-editorial-helper-translate-%d', $contentUid);
+
+        $html = sprintf(
+            '<div class="form-wizards-element">'
+            . '<button type="button" class="btn btn-default ai-editorial-helper-translate-stub" '
+            . 'id="%s" data-content-uid="%d">'
+            . '<span class="t3js-icon icon icon-size-small">🌐</span> %s'
+            . '</button>'
+            . '</div>',
+            $buttonId,
+            $contentUid,
+            htmlspecialchars($this->translate('wizard.translate_stub'), ENT_QUOTES, 'UTF-8'),
+        );
+
+        return [
+            'iconIdentifier' => null,
+            'html' => $html,
+            'javaScriptModules' => [
+                JavaScriptModuleInstruction::create('@kairos/ai-editorial-helper/translation-stub-wizard.js'),
+            ],
+            'stylesheetFiles' => [],
+            'requireJsModules' => [],
+            'additionalHiddenFields' => [],
+            'additionalInlineLanguageLabelFiles' => [],
+            'inlineData' => [],
+        ];
+    }
+
+    private function translate(string $key): string
+    {
+        $lang = $GLOBALS['LANG'] ?? null;
+        if ($lang !== null && method_exists($lang, 'sL')) {
+            $label = $lang->sL('LLL:EXT:ai_editorial_helper/Resources/Private/Language/locallang_be.xlf:' . $key);
+            if (is_string($label) && $label !== '') {
+                return $label;
+            }
+        }
+        return 'Generate translation stub';
+    }
+}

--- a/Classes/Service/TranslationStubService.php
+++ b/Classes/Service/TranslationStubService.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+
+/**
+ * Generates a starter DE↔EN translation of TYPO3 page bodytext.
+ *
+ * The output is a draft, not a final translation — editors review and refine.
+ * The service prepends a clearly-visible [STUB] marker so this never silently
+ * gets published as canonical content.
+ *
+ * Critical: HTML structure is preserved via DOMDocument. We do NOT feed raw
+ * HTML to the LLM and hope. Text nodes are extracted, sent to the LLM as a
+ * positional array, translated, and mapped back into the original DOM. Tags
+ * and attributes (href, src, class, …) survive unchanged.
+ *
+ * Supported languages: 'de' and 'en'. Anything else raises.
+ */
+class TranslationStubService
+{
+    public const SUPPORTED_LANGUAGES = ['de', 'en'];
+    public const STUB_PREFIX = '[STUB] ';
+
+    private const SCHEMA_NAME = 'AiEditorialTranslationResult';
+
+    /** Skip text nodes inside these elements — they don't contain translatable prose. */
+    private const NON_TRANSLATABLE_PARENTS = ['script', 'style', 'code', 'pre'];
+
+    /** Cap on number of text nodes per request — single LLM call only. */
+    private const MAX_NODES_PER_BATCH = 80;
+
+    public function __construct(
+        private readonly LmStudioClient $client,
+    ) {
+    }
+
+    /**
+     * Translate body HTML from source to target language.
+     *
+     * @throws LmStudioException When LM Studio is unreachable or returns an unusable response,
+     *                            or when language pair is unsupported.
+     */
+    public function translate(string $html, string $sourceLang, string $targetLang): string
+    {
+        $sourceLang = strtolower(trim($sourceLang));
+        $targetLang = strtolower(trim($targetLang));
+
+        $this->assertSupportedLanguage($sourceLang, 'source');
+        $this->assertSupportedLanguage($targetLang, 'target');
+
+        if ($sourceLang === $targetLang) {
+            // No-op: same language — still mark as stub so editor knows it was processed.
+            return $this->prependStubMarker($html);
+        }
+
+        if (trim($html) === '') {
+            throw new LmStudioException(
+                'Cannot translate: source content is empty.',
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        $doc = $this->loadHtml($html);
+        $textNodes = $this->collectTranslatableTextNodes($doc);
+
+        if ($textNodes === []) {
+            // HTML had only tags / non-text content — nothing to translate.
+            return $this->prependStubMarker($html);
+        }
+
+        if (count($textNodes) > self::MAX_NODES_PER_BATCH) {
+            // Too many nodes for a single call. Fail loudly rather than silently
+            // truncate — editor can split the content into smaller pieces.
+            throw new LmStudioException(
+                sprintf(
+                    'Content has too many text nodes (%d > %d). Translate in smaller chunks.',
+                    count($textNodes),
+                    self::MAX_NODES_PER_BATCH,
+                ),
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+
+        $items = [];
+        foreach ($textNodes as $i => $node) {
+            $items[] = ['index' => $i, 'text' => $node->nodeValue ?? ''];
+        }
+
+        $payload = $this->client->chatJsonSchema(
+            [
+                ['role' => 'system', 'content' => $this->buildSystemPrompt($sourceLang, $targetLang)],
+                ['role' => 'user', 'content' => json_encode($items, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)],
+            ],
+            self::SCHEMA_NAME,
+            $this->buildResponseSchema(count($items)),
+            ['temperature' => 0.2],
+        );
+
+        $this->applyTranslations($textNodes, $payload['translations'] ?? []);
+
+        $serialised = $this->serializeBody($doc);
+        return $this->prependStubMarker($serialised);
+    }
+
+    /**
+     * @return list<\DOMText>
+     */
+    private function collectTranslatableTextNodes(\DOMDocument $doc): array
+    {
+        $xpath = new \DOMXPath($doc);
+        $textNodes = [];
+        foreach ($xpath->query('//text()') ?: [] as $node) {
+            if (!$node instanceof \DOMText) {
+                continue;
+            }
+            $value = $node->nodeValue ?? '';
+            if (trim($value) === '') {
+                continue;
+            }
+            if ($this->hasNonTranslatableAncestor($node)) {
+                continue;
+            }
+            $textNodes[] = $node;
+        }
+        return $textNodes;
+    }
+
+    private function hasNonTranslatableAncestor(\DOMNode $node): bool
+    {
+        $parent = $node->parentNode;
+        while ($parent !== null) {
+            if ($parent instanceof \DOMElement
+                && in_array(strtolower($parent->nodeName), self::NON_TRANSLATABLE_PARENTS, true)
+            ) {
+                return true;
+            }
+            $parent = $parent->parentNode;
+        }
+        return false;
+    }
+
+    /**
+     * @param list<\DOMText> $textNodes
+     * @param array<int, mixed> $translations
+     */
+    private function applyTranslations(array $textNodes, array $translations): void
+    {
+        $byIndex = [];
+        foreach ($translations as $entry) {
+            if (!is_array($entry) || !isset($entry['index'], $entry['text'])) {
+                continue;
+            }
+            $byIndex[(int)$entry['index']] = (string)$entry['text'];
+        }
+
+        foreach ($textNodes as $i => $node) {
+            if (!array_key_exists($i, $byIndex)) {
+                continue;
+            }
+            // Preserve leading/trailing whitespace from the original node so layout
+            // and inter-word spacing don't shift. The LLM may have stripped them.
+            $original = $node->nodeValue ?? '';
+            $leading = $this->extractWhitespacePrefix($original);
+            $trailing = $this->extractWhitespaceSuffix($original);
+            $node->nodeValue = $leading . trim($byIndex[$i]) . $trailing;
+        }
+    }
+
+    private function extractWhitespacePrefix(string $value): string
+    {
+        if (preg_match('/^\s+/u', $value, $m) === 1) {
+            return $m[0];
+        }
+        return '';
+    }
+
+    private function extractWhitespaceSuffix(string $value): string
+    {
+        if (preg_match('/\s+$/u', $value, $m) === 1) {
+            return $m[0];
+        }
+        return '';
+    }
+
+    private function loadHtml(string $html): \DOMDocument
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        // Wrap in a root so loadHTML doesn't auto-add <html><body>. NOIMPLIED + NODEFDTD
+        // keep the document structure clean.
+        $wrapped = '<?xml encoding="UTF-8"?><ai-editorial-root>' . $html . '</ai-editorial-root>';
+        $doc->loadHTML($wrapped, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        return $doc;
+    }
+
+    private function serializeBody(\DOMDocument $doc): string
+    {
+        $root = $doc->getElementsByTagName('ai-editorial-root')->item(0);
+        if ($root === null) {
+            return '';
+        }
+        $result = '';
+        foreach ($root->childNodes as $child) {
+            $rendered = $doc->saveHTML($child);
+            if (is_string($rendered)) {
+                $result .= $rendered;
+            }
+        }
+        return $result;
+    }
+
+    private function prependStubMarker(string $html): string
+    {
+        // Always visible: prepend a paragraph the editor can't miss.
+        $marker = sprintf(
+            '<p data-ai-editorial-stub="1"><strong>%sAuto-generated translation. Please review.</strong></p>',
+            self::STUB_PREFIX,
+        );
+        return $marker . "\n" . $html;
+    }
+
+    private function buildSystemPrompt(string $sourceLang, string $targetLang): string
+    {
+        $sourceName = $this->languageName($sourceLang);
+        $targetName = $this->languageName($targetLang);
+
+        return <<<TXT
+You are a professional translator producing a draft translation from $sourceName to $targetName.
+
+You will receive a JSON array of objects: [{"index": int, "text": "..."}, ...].
+
+Return a JSON object with a single key "translations" — an array of {"index": int, "text": "..."}, ONE entry per input index.
+
+Rules:
+  - Translate the "text" field from $sourceName to $targetName, faithfully.
+  - Preserve the meaning. Do not summarise, expand, or editorialise.
+  - Do not add or remove sentences.
+  - Match the register: formal stays formal, informal stays informal.
+  - For proper nouns (names, brand names): keep verbatim.
+  - For numbers, dates, URLs, and code-like fragments: keep verbatim.
+  - The same indices must appear in the output array, exactly once each.
+TXT;
+    }
+
+    private function languageName(string $code): string
+    {
+        return match ($code) {
+            'de' => 'German',
+            'en' => 'English',
+            default => $code,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildResponseSchema(int $itemCount): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'translations' => [
+                    'type' => 'array',
+                    'minItems' => $itemCount,
+                    'maxItems' => $itemCount,
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'index' => ['type' => 'integer'],
+                            'text' => ['type' => 'string'],
+                        ],
+                        'required' => ['index', 'text'],
+                        'additionalProperties' => false,
+                    ],
+                ],
+            ],
+            'required' => ['translations'],
+            'additionalProperties' => false,
+        ];
+    }
+
+    private function assertSupportedLanguage(string $code, string $role): void
+    {
+        if (!in_array($code, self::SUPPORTED_LANGUAGES, true)) {
+            throw new LmStudioException(
+                sprintf('Unsupported %s language: "%s". Supported: %s', $role, $code, implode(', ', self::SUPPORTED_LANGUAGES)),
+                LmStudioException::CODE_INVALID_RESPONSE,
+            );
+        }
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -6,6 +6,7 @@ use Kairos\AiEditorialHelper\Controller\Ajax\CategorySuggesterAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\MetaDescriptionAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\SlugSuggesterAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\TeaserAjaxController;
+use Kairos\AiEditorialHelper\Controller\Ajax\TranslationStubAjaxController;
 
 return [
     'ai_editorial_helper_meta' => [
@@ -23,5 +24,9 @@ return [
     'ai_editorial_helper_teaser' => [
         'path' => '/ai-editorial-helper/teaser',
         'target' => TeaserAjaxController::class . '::generate',
+    ],
+    'ai_editorial_helper_translate' => [
+        'path' => '/ai-editorial-helper/translate',
+        'target' => TranslationStubAjaxController::class . '::generate',
     ],
 ];

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+defined('TYPO3') or die();
+
+/*
+ * Wire the AI translation-stub wizard into the tt_content bodytext field.
+ * The wizard itself decides at render time whether to surface the button
+ * (only on localised rows with l10n_source > 0).
+ *
+ * TCA mutations only — node-registry registration lives in ext_localconf.php.
+ */
+(static function (): void {
+    if (!isset($GLOBALS['TCA']['tt_content']['columns']['bodytext']['config'])) {
+        return;
+    }
+
+    $config = &$GLOBALS['TCA']['tt_content']['columns']['bodytext']['config'];
+    $config['fieldWizard'] = array_merge(
+        $config['fieldWizard'] ?? [],
+        [
+            'aiEditorialHelperTranslationStub' => [
+                'renderType' => 'aiEditorialHelperTranslationStub',
+            ],
+        ],
+    );
+})();

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -30,6 +30,15 @@
             <trans-unit id="notification.teaser_applied">
                 <source>Teaser generated. Review and save.</source>
             </trans-unit>
+            <trans-unit id="wizard.translate_stub">
+                <source>Generate translation stub</source>
+            </trans-unit>
+            <trans-unit id="wizard.translating">
+                <source>Translating…</source>
+            </trans-unit>
+            <trans-unit id="notification.translation_applied">
+                <source>Translation stub generated. Review and refine before saving.</source>
+            </trans-unit>
             <trans-unit id="notification.title">
                 <source>AI Editorial Helper</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/ajax-error.js
+++ b/Resources/Public/JavaScript/ajax-error.js
@@ -1,0 +1,33 @@
+/**
+ * Shared error-message extractor for AI Editorial Helper wizards.
+ *
+ * Background (issue #19): TYPO3's AjaxRequest rejects with an AjaxResponse
+ * object on non-2xx, NOT a JS Error. Naively casting that to String produces
+ * "[object Object]". We need to dig out the JSON body the controller sent
+ * (`{ success: false, error: "human-readable message" }`) and surface that.
+ *
+ * @param {unknown} err  Whatever the catch block received.
+ * @returns {Promise<string>}  A user-presentable error message.
+ */
+export async function extractAjaxErrorMessage(err) {
+  if (err && typeof err === "object" && err.response && typeof err.response.resolve === "function") {
+    try {
+      const body = await err.response.resolve();
+      if (body && typeof body === "object" && typeof body.error === "string" && body.error.length > 0) {
+        return body.error;
+      }
+    } catch (_inner) {
+      // fall through to status text
+    }
+    if (err.response.statusText) {
+      return err.response.statusText;
+    }
+    if (typeof err.response.status === "number") {
+      return `HTTP ${err.response.status}`;
+    }
+  }
+  if (err && typeof err === "object" && typeof err.message === "string" && err.message.length > 0) {
+    return err.message;
+  }
+  return String(err ?? "Unknown error");
+}

--- a/Resources/Public/JavaScript/translation-stub-wizard.js
+++ b/Resources/Public/JavaScript/translation-stub-wizard.js
@@ -1,0 +1,125 @@
+/**
+ * AI Editorial Helper — translation-stub wizard.
+ *
+ * Mounted as an ES module by GenerateTranslationStubWizard. On click, calls
+ * the AJAX endpoint to translate the source-language tt_content row into the
+ * current row's language. Patches the result into the bodytext field.
+ *
+ * Notes:
+ *   - The bodytext editor is typically CKEditor or RTE — we set the raw
+ *     hidden FormEngine input value, then dispatch change/blur. The RTE
+ *     re-binds on the change event in v13.
+ *   - Stripped HTML and unicode are preserved by the server-side DOMDocument
+ *     pipeline; the client just shoves the string in and lets FormEngine
+ *     re-render.
+ */
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
+import Notification from "@typo3/backend/notification.js";
+import { extractAjaxErrorMessage } from "@kairos/ai-editorial-helper/ajax-error.js";
+
+const SELECTOR = ".ai-editorial-helper-translate-stub";
+const BUSY_CLASS = "ai-editorial-helper-busy";
+
+function findBodytextInput(form) {
+  if (!form) {
+    return null;
+  }
+  // Match either the visible (RTE-managed) textarea or the raw hidden input.
+  return (
+    form.querySelector('textarea[data-formengine-input-name$="[bodytext]"]')
+    || form.querySelector('input[type="hidden"][data-formengine-input-name$="[bodytext]"]')
+    || form.querySelector('[data-formengine-input-name$="[bodytext]"]')
+  );
+}
+
+function syncHiddenCounterpart(input) {
+  const name = input.getAttribute("data-formengine-input-name");
+  if (!name) {
+    return;
+  }
+  const form = input.closest("form");
+  if (!form) {
+    return;
+  }
+  const hidden = form.querySelector(`input[type="hidden"][name="${CSS.escape(name)}"]`);
+  if (hidden && hidden !== input) {
+    hidden.value = input.value;
+  }
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+  input.dispatchEvent(new Event("blur", { bubbles: true }));
+}
+
+async function handleClick(event) {
+  const button = event.currentTarget;
+  if (button.classList.contains(BUSY_CLASS)) {
+    return;
+  }
+  const contentUid = parseInt(button.dataset.contentUid || "0", 10);
+  if (!contentUid) {
+    Notification.error("AI Editorial Helper", "No content UID — save the localisation first.");
+    return;
+  }
+
+  const form = button.closest("form");
+  button.classList.add(BUSY_CLASS);
+  button.disabled = true;
+  const originalText = button.textContent;
+  button.textContent = "Translating…";
+
+  try {
+    const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.ai_editorial_helper_translate)
+      .withQueryArguments({ contentUid })
+      .get();
+    const payload = await response.resolve();
+
+    if (!payload || payload.success !== true) {
+      throw new Error(payload && payload.error ? payload.error : "Unknown error");
+    }
+
+    const input = findBodytextInput(form);
+    if (!input) {
+      Notification.warning(
+        "AI Editorial Helper",
+        "Translated content but couldn't find the bodytext field.",
+      );
+      return;
+    }
+
+    input.value = payload.translation;
+    syncHiddenCounterpart(input);
+    Notification.success(
+      "AI Editorial Helper",
+      `Translation stub generated (${payload.sourceLang} → ${payload.targetLang}). Review and refine before saving.`,
+    );
+  } catch (err) {
+    const message = await extractAjaxErrorMessage(err);
+    Notification.error("AI Editorial Helper", message);
+  } finally {
+    button.classList.remove(BUSY_CLASS);
+    button.disabled = false;
+    button.textContent = originalText;
+  }
+}
+
+function bind(root) {
+  root.querySelectorAll(SELECTOR).forEach((button) => {
+    if (button.dataset.aiHelperBound === "1") {
+      return;
+    }
+    button.dataset.aiHelperBound = "1";
+    button.addEventListener("click", handleClick);
+  });
+}
+
+bind(document);
+
+const observer = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    mutation.addedNodes.forEach((node) => {
+      if (node instanceof HTMLElement) {
+        bind(node);
+      }
+    });
+  }
+});
+observer.observe(document.body, { childList: true, subtree: true });

--- a/Tests/Unit/Service/TranslationStubServiceTest.php
+++ b/Tests/Unit/Service/TranslationStubServiceTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+use Kairos\AiEditorialHelper\Service\TranslationStubService;
+use PHPUnit\Framework\TestCase;
+
+final class TranslationStubServiceTest extends TestCase
+{
+    public function testRejectsUnsupportedSourceLanguage(): void
+    {
+        $service = new TranslationStubService($this->createMock(LmStudioClient::class));
+        $this->expectException(LmStudioException::class);
+        $service->translate('<p>foo</p>', 'fr', 'en');
+    }
+
+    public function testRejectsUnsupportedTargetLanguage(): void
+    {
+        $service = new TranslationStubService($this->createMock(LmStudioClient::class));
+        $this->expectException(LmStudioException::class);
+        $service->translate('<p>foo</p>', 'de', 'fr');
+    }
+
+    public function testReturnsStubMarkerWhenSourceEqualsTarget(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::never())->method('chatJsonSchema');
+
+        $service = new TranslationStubService($client);
+        $result = $service->translate('<p>Hello.</p>', 'en', 'en');
+
+        self::assertStringContainsString(TranslationStubService::STUB_PREFIX, $result);
+        self::assertStringContainsString('<p>Hello.</p>', $result);
+    }
+
+    public function testRejectsEmptyContent(): void
+    {
+        $service = new TranslationStubService($this->createMock(LmStudioClient::class));
+        $this->expectException(LmStudioException::class);
+        $service->translate('   ', 'de', 'en');
+    }
+
+    public function testTranslatesSimpleParagraphPreservingTag(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->willReturn([
+                'translations' => [
+                    ['index' => 0, 'text' => 'Hello world.'],
+                ],
+            ]);
+
+        $service = new TranslationStubService($client);
+        $result = $service->translate('<p>Hallo Welt.</p>', 'de', 'en');
+
+        self::assertStringContainsString(TranslationStubService::STUB_PREFIX, $result);
+        self::assertStringContainsString('<p>Hello world.</p>', $result);
+        self::assertStringNotContainsString('Hallo Welt.', $result);
+    }
+
+    public function testPreservesAttributesOnLinks(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'translations' => [
+                ['index' => 0, 'text' => 'Visit '],
+                ['index' => 1, 'text' => 'our site'],
+                ['index' => 2, 'text' => '.'],
+            ],
+        ]);
+
+        $service = new TranslationStubService($client);
+        $result = $service->translate(
+            '<p>Besuche <a href="https://example.com" class="cta">unsere Seite</a>.</p>',
+            'de',
+            'en',
+        );
+
+        self::assertStringContainsString('href="https://example.com"', $result);
+        self::assertStringContainsString('class="cta"', $result);
+        self::assertStringContainsString('our site', $result);
+    }
+
+    public function testPreservesNestedStructure(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'translations' => [
+                ['index' => 0, 'text' => 'About us'],
+                ['index' => 1, 'text' => 'We are a digital agency.'],
+                ['index' => 2, 'text' => 'TYPO3'],
+                ['index' => 3, 'text' => ' and accessibility.'],
+            ],
+        ]);
+
+        $service = new TranslationStubService($client);
+        $result = $service->translate(
+            '<h1>Über uns</h1><p>Wir sind eine Digitalagentur.</p><ul><li><strong>TYPO3</strong> und Barrierefreiheit.</li></ul>',
+            'de',
+            'en',
+        );
+
+        self::assertStringContainsString('<h1>About us</h1>', $result);
+        self::assertStringContainsString('We are a digital agency.', $result);
+        self::assertStringContainsString('<strong>TYPO3</strong>', $result);
+        self::assertStringContainsString('accessibility.', $result);
+        self::assertStringContainsString('<ul>', $result);
+        self::assertStringContainsString('<li>', $result);
+    }
+
+    public function testSkipsScriptAndStyleContents(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(self::callback(function (array $messages): bool {
+                $userJson = $messages[1]['content'];
+                self::assertStringContainsString('Hallo', $userJson);
+                // script/style contents must not appear in the LLM input
+                self::assertStringNotContainsString('alert', $userJson);
+                self::assertStringNotContainsString('background', $userJson);
+                return true;
+            }))
+            ->willReturn(['translations' => [['index' => 0, 'text' => 'Hello']]]);
+
+        $service = new TranslationStubService($client);
+        $service->translate(
+            '<p>Hallo</p><script>alert("Hallo");</script><style>body { background: red; }</style>',
+            'de',
+            'en',
+        );
+    }
+
+    public function testHandlesPureMarkupWithNoText(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::never())->method('chatJsonSchema');
+
+        $service = new TranslationStubService($client);
+        $result = $service->translate('<hr><br><img src="x.jpg" alt="">', 'de', 'en');
+
+        self::assertStringContainsString(TranslationStubService::STUB_PREFIX, $result);
+    }
+
+    public function testPropagatesUnreachableException(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willThrowException(
+            new LmStudioException('refused', LmStudioException::CODE_UNREACHABLE),
+        );
+
+        $service = new TranslationStubService($client);
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_UNREACHABLE);
+        $service->translate('<p>foo</p>', 'de', 'en');
+    }
+
+    public function testIncludesLanguagePairInPrompt(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(self::callback(function (array $messages): bool {
+                $sys = $messages[0]['content'];
+                self::assertStringContainsString('German', $sys);
+                self::assertStringContainsString('English', $sys);
+                return true;
+            }))
+            ->willReturn(['translations' => [['index' => 0, 'text' => 'Hello']]]);
+
+        $service = new TranslationStubService($client);
+        $service->translate('<p>Hallo</p>', 'de', 'en');
+    }
+
+    public function testSchemaPinsArrayLength(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(
+                self::anything(),
+                self::equalTo('AiEditorialTranslationResult'),
+                self::callback(function (array $schema): bool {
+                    $items = $schema['properties']['translations'];
+                    self::assertSame(2, $items['minItems']);
+                    self::assertSame(2, $items['maxItems']);
+                    self::assertSame('integer', $items['items']['properties']['index']['type']);
+                    self::assertSame('string', $items['items']['properties']['text']['type']);
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn(['translations' => [
+                ['index' => 0, 'text' => 'Hello'],
+                ['index' => 1, 'text' => 'world'],
+            ]]);
+
+        $service = new TranslationStubService($client);
+        $service->translate('<p>Hallo</p><p>Welt</p>', 'de', 'en');
+    }
+
+    public function testRejectsContentWithTooManyTextNodes(): void
+    {
+        // Build content with > 80 text nodes — exceeds MAX_NODES_PER_BATCH.
+        $nodes = [];
+        for ($i = 0; $i < 100; $i++) {
+            $nodes[] = "<p>Absatz $i</p>";
+        }
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::never())->method('chatJsonSchema');
+
+        $service = new TranslationStubService($client);
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_INVALID_RESPONSE);
+        $service->translate(implode('', $nodes), 'de', 'en');
+    }
+
+    public function testHandlesTextWithUnicodeUmlauts(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'translations' => [
+                ['index' => 0, 'text' => 'About us'],
+            ],
+        ]);
+
+        $service = new TranslationStubService($client);
+        $result = $service->translate('<p>Über uns – Geschäftsbericht</p>', 'de', 'en');
+
+        self::assertStringContainsString('About us', $result);
+    }
+
+    public function testIgnoresMalformedTranslationEntriesGracefully(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'translations' => [
+                ['index' => 0, 'text' => 'Hello'],
+                ['index' => 99, 'text' => 'orphan — unused index'],
+                'not-an-object',
+                ['only-text-no-index' => 'foo'],
+            ],
+        ]);
+
+        $service = new TranslationStubService($client);
+        $result = $service->translate('<p>Hallo</p>', 'de', 'en');
+
+        self::assertStringContainsString('Hello', $result);
+        self::assertStringNotContainsString('orphan', $result);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,6 +6,7 @@ defined('TYPO3') or die();
 
 use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
 use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateTeaserWizard;
+use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateTranslationStubWizard;
 use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestCategoriesWizard;
 use Kairos\AiEditorialHelper\Form\FieldWizard\SuggestSlugWizard;
 
@@ -43,4 +44,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140103] = [
     'nodeName' => 'aiEditorialHelperSuggestCategories',
     'priority' => 40,
     'class' => SuggestCategoriesWizard::class,
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140104] = [
+    'nodeName' => 'aiEditorialHelperTranslationStub',
+    'priority' => 40,
+    'class' => GenerateTranslationStubWizard::class,
 ];


### PR DESCRIPTION
Implements [#5](https://github.com/backant-io/typo3-ai-helper/issues/5) — the signature demo feature for the German agency: prove the local LLM can draft real production content (DE↔EN) without sending it to OpenAI.

## What's included

- **`Classes/Service/TranslationStubService.php`** — DOMDocument-based pipeline. Parses bodytext HTML, walks text nodes via XPath, sends them to the LLM as a positional `[{index, text}]` array, applies translations back into the DOM, serialises. **Tags and attributes (`href`, `src`, `class`, …) survive unchanged.** Skips text inside `script` / `style` / `code` / `pre`. Caps at 80 text nodes per single-batch call. Always prepends a visible `[STUB]` paragraph so the draft can't be silently shipped.
- **`Classes/Controller/Ajax/TranslationStubAjaxController.php`** — loads the localised `tt_content` row, follows `l10n_source` to the original, derives source/target language codes via the site config, calls the service, returns `{ translation, sourceLang, targetLang }`. Refuses default-language rows (`l10n_source=0`). Uses the `?? []` fix-pattern from #19/PR #20 from the start.
- **`Classes/Form/FieldWizard/GenerateTranslationStubWizard.php`** — wizard registered against `tt_content.bodytext`. Renders the button only on localised rows with a source to translate from.
- **`Configuration/Backend/AjaxRoutes.php`** — adds `ai_editorial_helper_translate`.
- **`Configuration/TCA/Overrides/tt_content.php`** — first TCA override on `tt_content` (existing wizards target `pages.*`). TCA mutations only.
- **`ext_localconf.php`** — registers the wizard's renderType (issue #11 pattern: `nodeRegistry` NEVER lives in TCA overrides).
- **`Resources/Public/JavaScript/translation-stub-wizard.js`** — mounts on click, calls the endpoint, patches bodytext (handles RTE-managed textarea + hidden FormEngine input), uses the shared `extractAjaxErrorMessage` helper.
- **`Resources/Public/JavaScript/ajax-error.js`** — shared helper, identical to the one in PR #20. Whichever PR lands first wins; the second's add gets patch-deduped on `git rebase` (proven pattern from cycle 4).

## Why DOMDocument and not raw HTML→LLM

The issue is explicit: "Use DOMDocument or similar — do NOT just feed raw HTML to the LLM and hope." Local models will mangle attributes, drop tags, or invent `<p>` elements when given raw HTML. The DOM approach lets the LLM see a clean array of `{index, text}` entries, returns the same shape, and the service maps them back to the original DOM positions.

Schema pins `minItems == maxItems == nodeCount` so the LLM can't drop or add nodes — grammar enforcement guarantees the array shape matches the input.

## Tests — 83 / 83 ✓

```
$ docker run --rm -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit -c Tests/UnitTests.xml
…
OK (83 tests, 230 assertions)
```

15 new tests for `TranslationStubService` cover: language validation, empty rejection, source==target no-op, attribute preservation on links, nested structures (h1/p/ul/li/strong), script/style exclusion, pure-markup early-return, exception propagation, prompt content, schema array-length pinning, too-many-nodes failure, Unicode umlauts, malformed-response graceful degradation.

## Live integration check (qwen/qwen3-14b on LM Studio)

**DE → EN:**

Input:
```html
<h2>Über uns</h2><p>Wir sind eine <strong>Berliner Digitalagentur</strong> mit Fokus auf <a href="https://typo3.org">TYPO3</a> und Barrierefreiheit.</p><ul><li>Seit 2012 im DACH-Raum</li><li>Spezialisiert auf Performance</li></ul>
```

Output (after [STUB] prefix):
```html
<h2>About us</h2><p>We are a <strong>Berlin-based digital agency</strong> with a focus on <a href="https://typo3.org">TYPO3</a> and accessibility.</p><ul><li>Since 2012 in the DACH region</li><li>Specialised in performance</li></ul>
```

`<a href="https://typo3.org">` survived unchanged. `<strong>`, `<ul>`, `<li>` all preserved. Idiomatic English.

**EN → DE:**

Input:
```html
<h2>About us</h2><p>We help teams ship better content faster. Our editorial AI runs <em>locally</em> — no data leaves your server.</p>
```

Output:
```html
<h2>Über uns</h2><p>Wir helfen Teams, besserer Content schneller zu veröffentlichen. Unsere redaktionelle KI läuft <em>lokal</em> – keine Daten verlassen Ihren Server.</p>
```

`<em>` preserved, idiomatic German. Minor case error ("besserer" → should be "besseren") — exactly the kind of tweak a human editor reviews. The `[STUB]` marker makes that invitation explicit.

## Acceptance-criteria checklist

- [x] `translate(string $content, string $sourceLang, string $targetLang): string`. Supports `de` + `en` both ways.
- [x] **Preserves HTML structure: passes through tags, only translates text nodes.** Uses DOMDocument + XPath, NOT raw HTML to the LLM.
- [x] Backend integration: *Generate translation stub* button on translated `tt_content` rows (`l10n_source > 0` && `sys_language_uid > 0`).
- [x] PHPUnit tests with mocked `LmStudioClient`. Covers: short DE → EN, short EN → DE, content with `<p>` / `<a>` / `<strong>` (structure preserved), Unicode umlauts.
- [x] **Clearly marks the output as a draft** — prepends `<p><strong>[STUB] Auto-generated translation. Please review.</strong></p>` paragraph + `data-ai-editorial-stub="1"` data attribute for further styling.
- [x] Out of scope: languages other than DE/EN; auto-translation on save; non-bodytext fields.

Closes #5.