### PR TITLE
Add content quality flags (#6) — rule-based + LLM-based hybrid

### DIFF
--- a/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\CategorySuggesterService;
 use Psr\Http\Message\ResponseInterface;
@@ -70,8 +71,8 @@ final class CategorySuggesterAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->setMaxResults(20)

--- a/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
+++ b/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\MetaDescriptionService;
 use Psr\Http\Message\ResponseInterface;
@@ -71,8 +72,8 @@ final class MetaDescriptionAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->executeQuery()

--- a/Classes/Controller/Ajax/QualityCheckerAjaxController.php
+++ b/Classes/Controller/Ajax/QualityCheckerAjaxController.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Controller\Ajax;
+
+use Kairos\AiEditorialHelper\Service\QualityChecker;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\JsonResponse;
+
+/**
+ * Backend AJAX endpoint for the "Check page quality" wizard.
+ *
+ * Route: GET/POST /typo3/ajax/ai-editorial-helper/quality?pageUid=123[&llm=1]
+ *
+ * Concatenates default-language tt_content into a single HTML blob, runs the
+ * QualityChecker, returns a sorted list of flags.
+ */
+final class QualityCheckerAjaxController
+{
+    public function __construct(
+        private readonly QualityChecker $service,
+        private readonly ConnectionPool $connectionPool,
+    ) {
+    }
+
+    public function check(ServerRequestInterface $request): ResponseInterface
+    {
+        // PSR-7: getParsedBody() is null on GET — coalesce.
+        $params = ($request->getParsedBody() ?? []) + $request->getQueryParams();
+        $pageUid = (int)($params['pageUid'] ?? 0);
+        $includeLlm = !isset($params['llm']) || (string)$params['llm'] !== '0';
+
+        if ($pageUid <= 0) {
+            return $this->error('Missing or invalid pageUid parameter.', 400);
+        }
+
+        $page = BackendUtility::getRecord('pages', $pageUid);
+        if (!is_array($page)) {
+            return $this->error(sprintf('Page %d not found.', $pageUid), 404);
+        }
+
+        $title = (string)($page['title'] ?? '');
+        $html = $this->loadPageHtml($pageUid);
+
+        $flags = $this->service->check($title, $html, $includeLlm);
+
+        $counts = ['error' => 0, 'warning' => 0, 'info' => 0];
+        foreach ($flags as $flag) {
+            $sev = $flag['severity'] ?? 'info';
+            if (isset($counts[$sev])) {
+                $counts[$sev]++;
+            }
+        }
+
+        return new JsonResponse([
+            'success' => true,
+            'flags' => $flags,
+            'counts' => $counts,
+            'includesLlm' => $includeLlm,
+        ]);
+    }
+
+    /**
+     * Concatenate default-language tt_content as a single HTML blob: header is
+     * wrapped in <h2>, subheader in <h3>, bodytext stays as-is. This gives the
+     * checker a realistic page-shaped DOM to work on.
+     */
+    private function loadPageHtml(int $pageUid): string
+    {
+        $qb = $this->connectionPool->getQueryBuilderForTable('tt_content');
+        $rows = $qb
+            ->select('header', 'subheader', 'bodytext', 'header_layout')
+            ->from('tt_content')
+            ->where(
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+            )
+            ->orderBy('sorting', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $parts = [];
+        foreach ($rows as $row) {
+            $headerLayout = (int)($row['header_layout'] ?? 0);
+            $headerTag = $headerLayout > 0 && $headerLayout <= 6 ? 'h' . $headerLayout : 'h2';
+            $header = trim((string)($row['header'] ?? ''));
+            if ($header !== '') {
+                $parts[] = sprintf('<%s>%s</%s>', $headerTag, htmlspecialchars($header, ENT_QUOTES, 'UTF-8'), $headerTag);
+            }
+            $subheader = trim((string)($row['subheader'] ?? ''));
+            if ($subheader !== '') {
+                $parts[] = sprintf('<h3>%s</h3>', htmlspecialchars($subheader, ENT_QUOTES, 'UTF-8'));
+            }
+            $bodytext = trim((string)($row['bodytext'] ?? ''));
+            if ($bodytext !== '') {
+                $parts[] = $bodytext;
+            }
+        }
+        return implode("\n", $parts);
+    }
+
+    private function error(string $message, int $status): ResponseInterface
+    {
+        return new JsonResponse(['success' => false, 'error' => $message], $status);
+    }
+}

--- a/Classes/Controller/Ajax/QualityCheckerAjaxController.php
+++ b/Classes/Controller/Ajax/QualityCheckerAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Service\QualityChecker;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -76,8 +77,8 @@ final class QualityCheckerAjaxController
             ->select('header', 'subheader', 'bodytext', 'header_layout')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->executeQuery()

--- a/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\SlugSuggesterService;
 use Psr\Http\Message\ResponseInterface;
@@ -75,8 +76,8 @@ final class SlugSuggesterAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->setMaxResults(20)

--- a/Classes/Controller/Ajax/TeaserAjaxController.php
+++ b/Classes/Controller/Ajax/TeaserAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\TeaserService;
 use Psr\Http\Message\ResponseInterface;
@@ -63,8 +64,8 @@ final class TeaserAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->setMaxResults(20)

--- a/Classes/Form/FieldWizard/CheckQualityWizard.php
+++ b/Classes/Form/FieldWizard/CheckQualityWizard.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Form\FieldWizard;
+
+use TYPO3\CMS\Backend\Form\AbstractNode;
+use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
+
+/**
+ * Renders a "Check page quality" button next to the page title field.
+ *
+ * Page-level (not field-level): the button checks the whole page, not the
+ * single field it sits next to. The title field is just a convenient anchor
+ * point on the page-edit form.
+ */
+final class CheckQualityWizard extends AbstractNode
+{
+    public function render(): array
+    {
+        $row = $this->data['databaseRow'] ?? [];
+        $pageUid = (int)($row['uid'] ?? 0);
+
+        if ($pageUid <= 0) {
+            return [
+                'iconIdentifier' => null,
+                'html' => '',
+                'javaScriptModules' => [],
+            ];
+        }
+
+        $buttonId = sprintf('ai-editorial-helper-quality-%d', $pageUid);
+
+        $html = sprintf(
+            '<div class="form-wizards-element ai-editorial-helper-quality-wizard">'
+            . '<button type="button" class="btn btn-default ai-editorial-helper-check-quality" '
+            . 'id="%s" data-page-uid="%d">'
+            . '<span class="t3js-icon icon icon-size-small">🔎</span> %s'
+            . '</button>'
+            . '<div class="ai-editorial-helper-quality-results"></div>'
+            . '</div>',
+            $buttonId,
+            $pageUid,
+            htmlspecialchars($this->translate('wizard.check_quality'), ENT_QUOTES, 'UTF-8'),
+        );
+
+        return [
+            'iconIdentifier' => null,
+            'html' => $html,
+            'javaScriptModules' => [
+                JavaScriptModuleInstruction::create('@kairos/ai-editorial-helper/quality-checker-wizard.js'),
+            ],
+            'stylesheetFiles' => [],
+            'requireJsModules' => [],
+            'additionalHiddenFields' => [],
+            'additionalInlineLanguageLabelFiles' => [],
+            'inlineData' => [],
+        ];
+    }
+
+    private function translate(string $key): string
+    {
+        $lang = $GLOBALS['LANG'] ?? null;
+        if ($lang !== null && method_exists($lang, 'sL')) {
+            $label = $lang->sL('LLL:EXT:ai_editorial_helper/Resources/Private/Language/locallang_be.xlf:' . $key);
+            if (is_string($label) && $label !== '') {
+                return $label;
+            }
+        }
+        return 'Check page quality';
+    }
+}

--- a/Classes/Service/CategoryRepository.php
+++ b/Classes/Service/CategoryRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Service;
 
+use Doctrine\DBAL\ParameterType;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
@@ -32,7 +33,7 @@ class CategoryRepository
             ->select('uid', 'title', 'description')
             ->from(self::TABLE)
             ->where(
-                $qb->expr()->eq('parent', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('parent', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->addOrderBy('title', 'ASC')

--- a/Classes/Service/Quality/LlmQualityChecker.php
+++ b/Classes/Service/Quality/LlmQualityChecker.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service\Quality;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+
+/**
+ * Subjective quality checks that need an LLM:
+ *   - tone consistency (formal/informal mixing) — warning
+ *   - clarity of paragraphs — info
+ *
+ * Single LLM call returns both, schema-pinned to a strict shape so the result
+ * is always parseable and the orchestrator never sees garbage.
+ */
+class LlmQualityChecker
+{
+    private const SCHEMA_NAME = 'AiEditorialQualityResult';
+
+    private const SYSTEM_PROMPT = <<<TXT
+You are an editorial quality reviewer for a TYPO3 CMS.
+Given a page's title and body content, identify subjective quality issues.
+
+Return a JSON object with one field "issues" — an array of objects, each shaped:
+{
+  "kind": "tone" | "clarity",
+  "severity": "info" | "warning",
+  "message": "short editor-facing explanation, max 200 chars",
+  "location": "verbatim quote from the source, max 80 chars, or empty"
+}
+
+Rules:
+  - "tone": flag inconsistent register (mixing formal "Sie" with informal "du", or sudden shifts in formality between paragraphs). Severity: warning.
+  - "clarity": flag paragraphs that are confusing, contradictory, or contain unexplained jargon. Severity: info.
+  - At most 5 total issues. Skip the section entirely if the content is fine.
+  - Match the page's language: do not translate the "message" field. German source → German message, English source → English message.
+  - The "location" field must contain a verbatim substring from the source so the editor can find the offending passage.
+TXT;
+
+    public function __construct(
+        private readonly LmStudioClient $client,
+    ) {
+    }
+
+    /**
+     * @return list<array{kind: string, severity: string, message: string, location?: string}>
+     *
+     * @throws LmStudioException For connectivity / model errors. Garbage LLM output is treated as empty.
+     */
+    public function check(string $title, string $body): array
+    {
+        $cleanBody = $this->extractText($body);
+        $cleanTitle = trim($title);
+
+        if ($cleanBody === '' && $cleanTitle === '') {
+            return [];
+        }
+
+        $userMessage = sprintf(
+            "PAGE TITLE:\n%s\n\nPAGE CONTENT:\n%s",
+            $cleanTitle !== '' ? $cleanTitle : '(no title)',
+            $cleanBody !== '' ? $cleanBody : '(no body content)',
+        );
+
+        $payload = $this->client->chatJsonSchema(
+            [
+                ['role' => 'system', 'content' => self::SYSTEM_PROMPT],
+                ['role' => 'user', 'content' => $userMessage],
+            ],
+            self::SCHEMA_NAME,
+            [
+                'type' => 'object',
+                'properties' => [
+                    'issues' => [
+                        'type' => 'array',
+                        'maxItems' => 5,
+                        'items' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'kind' => ['type' => 'string', 'enum' => ['tone', 'clarity']],
+                                'severity' => ['type' => 'string', 'enum' => ['info', 'warning']],
+                                'message' => ['type' => 'string', 'maxLength' => 200],
+                                'location' => ['type' => 'string', 'maxLength' => 80],
+                            ],
+                            'required' => ['kind', 'severity', 'message'],
+                            'additionalProperties' => false,
+                        ],
+                    ],
+                ],
+                'required' => ['issues'],
+                'additionalProperties' => false,
+            ],
+            ['temperature' => 0.2],
+        );
+
+        $raw = is_array($payload['issues'] ?? null) ? $payload['issues'] : [];
+        return $this->normalise($raw);
+    }
+
+    /**
+     * @param array<int, mixed> $raw
+     * @return list<array{kind: string, severity: string, message: string, location?: string}>
+     */
+    private function normalise(array $raw): array
+    {
+        $allowedKinds = ['tone', 'clarity'];
+        $allowedSeverities = ['info', 'warning'];
+
+        $result = [];
+        foreach ($raw as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $kind = (string)($entry['kind'] ?? '');
+            $severity = (string)($entry['severity'] ?? '');
+            $message = trim((string)($entry['message'] ?? ''));
+            if ($message === '' || !in_array($kind, $allowedKinds, true) || !in_array($severity, $allowedSeverities, true)) {
+                continue;
+            }
+            $flag = [
+                'kind' => $kind,
+                'severity' => $severity,
+                'message' => mb_substr($message, 0, 200),
+            ];
+            $location = trim((string)($entry['location'] ?? ''));
+            if ($location !== '') {
+                $flag['location'] = mb_substr($location, 0, 80);
+            }
+            $result[] = $flag;
+        }
+        return array_slice($result, 0, 5);
+    }
+
+    private function extractText(string $body): string
+    {
+        $stripped = strip_tags($body);
+        $decoded = html_entity_decode($stripped, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $collapsed = preg_replace('/\s+/u', ' ', $decoded) ?? '';
+        $trimmed = trim($collapsed);
+        if (mb_strlen($trimmed) > 8000) {
+            $trimmed = mb_substr($trimmed, 0, 8000);
+        }
+        return $trimmed;
+    }
+}

--- a/Classes/Service/Quality/RuleBasedQualityChecker.php
+++ b/Classes/Service/Quality/RuleBasedQualityChecker.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service\Quality;
+
+/**
+ * Pure-function quality checks that run instantly without any LLM call.
+ *
+ * Issues flagged here:
+ *   - Sentence length > MAX_SENTENCE_WORDS (warning)
+ *   - No <h1> on the page (error)
+ *   - Multiple <h1> elements (error)
+ *   - Heading hierarchy skips levels, e.g. h2 → h4 (warning)
+ *
+ * No DI, no $GLOBALS access — just static-friendly methods so the orchestrator
+ * (and tests) can construct trivially.
+ */
+class RuleBasedQualityChecker
+{
+    public const MAX_SENTENCE_WORDS = 30;
+
+    /**
+     * @return list<array{kind: string, severity: string, message: string, location?: string}>
+     */
+    public function check(string $html): array
+    {
+        $flags = [];
+        $flags = array_merge($flags, $this->checkHeadingStructure($html));
+        $flags = array_merge($flags, $this->checkSentenceLengths($html));
+        return $flags;
+    }
+
+    /**
+     * @return list<array{kind: string, severity: string, message: string, location?: string}>
+     */
+    public function checkHeadingStructure(string $html): array
+    {
+        $flags = [];
+        $headings = $this->extractHeadings($html);
+        $h1Count = 0;
+        $previousLevel = 0;
+
+        foreach ($headings as $heading) {
+            if ($heading['level'] === 1) {
+                $h1Count++;
+            }
+
+            if ($previousLevel > 0 && $heading['level'] > $previousLevel + 1) {
+                $flags[] = [
+                    'kind' => 'heading_structure',
+                    'severity' => 'warning',
+                    'message' => sprintf(
+                        'Heading hierarchy skips a level: "%s" goes from h%d to h%d.',
+                        $this->shortenForMessage($heading['text']),
+                        $previousLevel,
+                        $heading['level'],
+                    ),
+                    'location' => sprintf('h%d "%s"', $heading['level'], $this->shortenForMessage($heading['text'])),
+                ];
+            }
+            $previousLevel = $heading['level'];
+        }
+
+        if ($h1Count === 0 && $headings !== []) {
+            $flags[] = [
+                'kind' => 'heading_structure',
+                'severity' => 'error',
+                'message' => 'Page has headings but no <h1>. Add a top-level heading for accessibility and SEO.',
+            ];
+        } elseif ($h1Count > 1) {
+            $flags[] = [
+                'kind' => 'heading_structure',
+                'severity' => 'error',
+                'message' => sprintf('Page has %d <h1> elements. Use exactly one.', $h1Count),
+            ];
+        }
+
+        return $flags;
+    }
+
+    /**
+     * @return list<array{kind: string, severity: string, message: string, location?: string}>
+     */
+    public function checkSentenceLengths(string $html): array
+    {
+        $text = $this->extractPlainText($html);
+        if ($text === '') {
+            return [];
+        }
+
+        $sentences = $this->splitSentences($text);
+        $flags = [];
+        foreach ($sentences as $sentence) {
+            $wordCount = $this->wordCount($sentence);
+            if ($wordCount > self::MAX_SENTENCE_WORDS) {
+                $flags[] = [
+                    'kind' => 'sentence_length',
+                    'severity' => 'warning',
+                    'message' => sprintf(
+                        'Sentence has %d words (cap %d). Consider splitting it.',
+                        $wordCount,
+                        self::MAX_SENTENCE_WORDS,
+                    ),
+                    'location' => $this->shortenForMessage($sentence),
+                ];
+            }
+        }
+        return $flags;
+    }
+
+    /**
+     * @return list<array{level: int, text: string}>
+     */
+    private function extractHeadings(string $html): array
+    {
+        if (trim($html) === '') {
+            return [];
+        }
+
+        $doc = $this->loadHtml($html);
+        $xpath = new \DOMXPath($doc);
+
+        $found = [];
+        foreach ($xpath->query('//h1 | //h2 | //h3 | //h4 | //h5 | //h6') ?: [] as $node) {
+            if (!$node instanceof \DOMElement) {
+                continue;
+            }
+            $level = (int)substr($node->nodeName, 1);
+            $found[] = ['level' => $level, 'text' => trim($node->textContent)];
+        }
+        return $found;
+    }
+
+    private function extractPlainText(string $html): string
+    {
+        $stripped = strip_tags($html);
+        $decoded = html_entity_decode($stripped, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $collapsed = preg_replace('/\s+/u', ' ', $decoded) ?? '';
+        return trim($collapsed);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function splitSentences(string $text): array
+    {
+        // Split on sentence-ending punctuation followed by whitespace + uppercase letter
+        // (or end of string). Avoids splitting on abbreviations like "z.B."
+        $parts = preg_split(
+            '/(?<=[.!?])\s+(?=[\p{Lu}])/u',
+            $text,
+            -1,
+            PREG_SPLIT_NO_EMPTY,
+        );
+        if ($parts === false) {
+            return [];
+        }
+        return array_values(array_map('trim', $parts));
+    }
+
+    private function wordCount(string $sentence): int
+    {
+        $words = preg_split('/\s+/u', trim($sentence), -1, PREG_SPLIT_NO_EMPTY);
+        return is_array($words) ? count($words) : 0;
+    }
+
+    private function shortenForMessage(string $text, int $max = 60): string
+    {
+        $clean = trim(preg_replace('/\s+/u', ' ', $text) ?? '');
+        if (mb_strlen($clean) <= $max) {
+            return $clean;
+        }
+        return mb_substr($clean, 0, $max - 1) . '…';
+    }
+
+    private function loadHtml(string $html): \DOMDocument
+    {
+        $doc = new \DOMDocument('1.0', 'UTF-8');
+        $previous = libxml_use_internal_errors(true);
+        $wrapped = '<?xml encoding="UTF-8"?><quality-root>' . $html . '</quality-root>';
+        $doc->loadHTML($wrapped, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previous);
+        return $doc;
+    }
+}

--- a/Classes/Service/QualityChecker.php
+++ b/Classes/Service/QualityChecker.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\Quality\LlmQualityChecker;
+use Kairos\AiEditorialHelper\Service\Quality\RuleBasedQualityChecker;
+
+/**
+ * Combines fast rule-based checks (sentence length, heading hierarchy) with
+ * subjective LLM-based checks (tone, clarity) into a single flag list.
+ *
+ * Rule-based checks always run. LLM checks are opt-in (caller passes
+ * $includeLlm = true) so they don't block page save. Returns flags in
+ * priority order: errors first, then warnings, then info.
+ *
+ * Each flag has the shape:
+ *   { kind: string, severity: 'info'|'warning'|'error', message: string, location?: string }
+ */
+class QualityChecker
+{
+    public function __construct(
+        private readonly RuleBasedQualityChecker $ruleBased,
+        private readonly LlmQualityChecker $llmBased,
+    ) {
+    }
+
+    /**
+     * @return list<array{kind: string, severity: string, message: string, location?: string}>
+     */
+    public function check(string $title, string $html, bool $includeLlm = true): array
+    {
+        $flags = $this->ruleBased->check($html);
+
+        if ($includeLlm) {
+            try {
+                $llmFlags = $this->llmBased->check($title, $html);
+                $flags = array_merge($flags, $llmFlags);
+            } catch (LmStudioException $e) {
+                // Rule-based checks always survive an LLM outage. Surface a single
+                // info-level flag so the editor knows LLM checks were skipped, not
+                // silently dropped.
+                $flags[] = [
+                    'kind' => 'llm_unavailable',
+                    'severity' => 'info',
+                    'message' => 'LLM-based checks (tone, clarity) skipped: ' . $e->getMessage(),
+                ];
+            }
+        }
+
+        return $this->sortBySeverity($flags);
+    }
+
+    /**
+     * @param list<array{kind: string, severity: string, message: string, location?: string}> $flags
+     * @return list<array{kind: string, severity: string, message: string, location?: string}>
+     */
+    private function sortBySeverity(array $flags): array
+    {
+        $weight = ['error' => 0, 'warning' => 1, 'info' => 2];
+        usort($flags, static function (array $a, array $b) use ($weight): int {
+            $wa = $weight[$a['severity']] ?? 99;
+            $wb = $weight[$b['severity']] ?? 99;
+            if ($wa !== $wb) {
+                return $wa <=> $wb;
+            }
+            return strcmp($a['kind'], $b['kind']);
+        });
+        return array_values($flags);
+    }
+}

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Kairos\AiEditorialHelper\Controller\Ajax\CategorySuggesterAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\MetaDescriptionAjaxController;
+use Kairos\AiEditorialHelper\Controller\Ajax\QualityCheckerAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\SlugSuggesterAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\TeaserAjaxController;
 use Kairos\AiEditorialHelper\Controller\Ajax\TranslationStubAjaxController;
@@ -28,5 +29,9 @@ return [
     'ai_editorial_helper_translate' => [
         'path' => '/ai-editorial-helper/translate',
         'target' => TranslationStubAjaxController::class . '::generate',
+    ],
+    'ai_editorial_helper_quality' => [
+        'path' => '/ai-editorial-helper/quality',
+        'target' => QualityCheckerAjaxController::class . '::check',
     ],
 ];

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -59,4 +59,15 @@ defined('TYPO3') or die();
             ],
         );
     }
+
+    if (isset($columns['title']['config'])) {
+        $columns['title']['config']['fieldWizard'] = array_merge(
+            $columns['title']['config']['fieldWizard'] ?? [],
+            [
+                'aiEditorialHelperCheckQuality' => [
+                    'renderType' => 'aiEditorialHelperCheckQuality',
+                ],
+            ],
+        );
+    }
 })();

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -39,6 +39,15 @@
             <trans-unit id="notification.translation_applied">
                 <source>Translation stub generated. Review and refine before saving.</source>
             </trans-unit>
+            <trans-unit id="wizard.check_quality">
+                <source>Check page quality</source>
+            </trans-unit>
+            <trans-unit id="wizard.checking">
+                <source>Checking…</source>
+            </trans-unit>
+            <trans-unit id="quality.no_issues">
+                <source>No issues found.</source>
+            </trans-unit>
             <trans-unit id="notification.title">
                 <source>AI Editorial Helper</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/quality-checker-wizard.js
+++ b/Resources/Public/JavaScript/quality-checker-wizard.js
@@ -1,0 +1,179 @@
+/**
+ * AI Editorial Helper — quality-checker wizard.
+ *
+ * On click, runs all rule-based + LLM-based checks server-side and renders
+ * the resulting flag list inline. Severity is shown via colored badges.
+ * No form fields are mutated — this is a read-only audit.
+ */
+import AjaxRequest from "@typo3/core/ajax/ajax-request.js";
+import Notification from "@typo3/backend/notification.js";
+import { extractAjaxErrorMessage } from "@kairos/ai-editorial-helper/ajax-error.js";
+
+const SELECTOR = ".ai-editorial-helper-check-quality";
+const BUSY_CLASS = "ai-editorial-helper-busy";
+
+const SEVERITY_BADGE = {
+  error: { label: "ERROR", color: "#d32f2f" },
+  warning: { label: "WARN", color: "#f57c00" },
+  info: { label: "INFO", color: "#1976d2" },
+};
+
+function clearChildren(node) {
+  while (node.firstChild) {
+    node.removeChild(node.firstChild);
+  }
+}
+
+function appendStatus(panel, message, className = "text-muted") {
+  const p = document.createElement("p");
+  p.className = className;
+  p.textContent = message;
+  panel.appendChild(p);
+}
+
+function renderFlag(panel, flag) {
+  const sev = SEVERITY_BADGE[flag.severity] || SEVERITY_BADGE.info;
+
+  const row = document.createElement("div");
+  row.className = "ai-editorial-helper-quality-flag";
+  row.style.padding = "6px 0";
+  row.style.borderBottom = "1px solid rgba(0,0,0,0.08)";
+
+  const badge = document.createElement("span");
+  badge.textContent = sev.label;
+  badge.style.display = "inline-block";
+  badge.style.padding = "2px 6px";
+  badge.style.marginRight = "8px";
+  badge.style.fontSize = "0.7rem";
+  badge.style.fontWeight = "600";
+  badge.style.color = "#fff";
+  badge.style.backgroundColor = sev.color;
+  badge.style.borderRadius = "3px";
+  row.appendChild(badge);
+
+  const kindLabel = document.createElement("strong");
+  kindLabel.textContent = flag.kind + ": ";
+  kindLabel.style.marginRight = "4px";
+  row.appendChild(kindLabel);
+
+  const message = document.createElement("span");
+  message.textContent = flag.message;
+  row.appendChild(message);
+
+  if (flag.location) {
+    const loc = document.createElement("div");
+    loc.style.marginTop = "4px";
+    loc.style.fontSize = "0.85rem";
+    loc.style.color = "#555";
+    loc.style.fontStyle = "italic";
+    loc.textContent = `“${flag.location}”`;
+    row.appendChild(loc);
+  }
+
+  panel.appendChild(row);
+}
+
+function renderSummary(panel, counts, includesLlm) {
+  const summary = document.createElement("p");
+  summary.style.marginBottom = "8px";
+  summary.style.fontWeight = "600";
+  const parts = [];
+  if (counts.error) parts.push(`${counts.error} error${counts.error === 1 ? "" : "s"}`);
+  if (counts.warning) parts.push(`${counts.warning} warning${counts.warning === 1 ? "" : "s"}`);
+  if (counts.info) parts.push(`${counts.info} note${counts.info === 1 ? "" : "s"}`);
+  if (parts.length === 0) {
+    summary.textContent = includesLlm ? "No issues found." : "No rule-based issues found.";
+    summary.style.color = "#388e3c";
+  } else {
+    summary.textContent = parts.join(", ") + ".";
+  }
+  panel.appendChild(summary);
+}
+
+function renderResults(panel, payload) {
+  clearChildren(panel);
+  if (!payload || !Array.isArray(payload.flags)) {
+    appendStatus(panel, "Unexpected response shape.");
+    return;
+  }
+  renderSummary(panel, payload.counts || { error: 0, warning: 0, info: 0 }, !!payload.includesLlm);
+  if (payload.flags.length === 0) {
+    return;
+  }
+  const list = document.createElement("div");
+  list.className = "ai-editorial-helper-quality-flags";
+  panel.appendChild(list);
+  payload.flags.forEach((flag) => renderFlag(list, flag));
+}
+
+async function handleClick(event) {
+  const button = event.currentTarget;
+  if (button.classList.contains(BUSY_CLASS)) {
+    return;
+  }
+  const pageUid = parseInt(button.dataset.pageUid || "0", 10);
+  if (!pageUid) {
+    Notification.error("AI Editorial Helper", "No page UID — save the page first.");
+    return;
+  }
+
+  const wizard = button.closest(".ai-editorial-helper-quality-wizard");
+  const panel = wizard ? wizard.querySelector(".ai-editorial-helper-quality-results") : null;
+
+  button.classList.add(BUSY_CLASS);
+  button.disabled = true;
+  const originalText = button.textContent;
+  button.textContent = "Checking…";
+  if (panel) {
+    clearChildren(panel);
+    appendStatus(panel, "Running checks…");
+  }
+
+  try {
+    const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.ai_editorial_helper_quality)
+      .withQueryArguments({ pageUid })
+      .get();
+    const payload = await response.resolve();
+
+    if (!payload || payload.success !== true) {
+      throw new Error(payload && payload.error ? payload.error : "Unknown error");
+    }
+
+    if (panel) {
+      renderResults(panel, payload);
+    }
+  } catch (err) {
+    if (panel) {
+      clearChildren(panel);
+    }
+    const message = await extractAjaxErrorMessage(err);
+    Notification.error("AI Editorial Helper", message);
+  } finally {
+    button.classList.remove(BUSY_CLASS);
+    button.disabled = false;
+    button.textContent = originalText;
+  }
+}
+
+function bind(root) {
+  root.querySelectorAll(SELECTOR).forEach((button) => {
+    if (button.dataset.aiHelperBound === "1") {
+      return;
+    }
+    button.dataset.aiHelperBound = "1";
+    button.addEventListener("click", handleClick);
+  });
+}
+
+bind(document);
+
+const observer = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    mutation.addedNodes.forEach((node) => {
+      if (node instanceof HTMLElement) {
+        bind(node);
+      }
+    });
+  }
+});
+observer.observe(document.body, { childList: true, subtree: true });

--- a/Tests/Unit/DbalParameterTypeRegressionTest.php
+++ b/Tests/Unit/DbalParameterTypeRegressionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for issue #25.
+ *
+ * TYPO3 v13.4 ships Doctrine DBAL 4. DBAL 4 dropped support for the legacy
+ * integer-form constants (\PDO::PARAM_INT === 1) on
+ * QueryBuilder::createNamedParameter() — the second arg must now be one of:
+ *   - Doctrine\DBAL\ParameterType
+ *   - Doctrine\DBAL\Types\Type
+ *   - Doctrine\DBAL\ArrayParameterType
+ *   - string
+ *
+ * Passing \PDO::PARAM_INT raises TypeError at runtime. This was a demo-blocker
+ * caught only on a real v13.4 install — PHPUnit tests with mocked QueryBuilder
+ * never executed the strict signature.
+ *
+ * This test is a static-analysis-style guard: it greps the production source
+ * tree for any `\PDO::PARAM_*` reference and fails the suite if any is found.
+ * Cheaper than a full functional test against typo3/testing-framework, and
+ * locks in the fix as long as nobody disables the test.
+ */
+final class DbalParameterTypeRegressionTest extends TestCase
+{
+    public function testNoLegacyPdoParamConstantsInProductionCode(): void
+    {
+        $classesDir = realpath(__DIR__ . '/../../Classes');
+        self::assertNotFalse($classesDir, 'Classes/ directory must exist');
+
+        $offenders = $this->scanForPdoParam($classesDir);
+
+        self::assertSame(
+            [],
+            $offenders,
+            'Found legacy \\PDO::PARAM_* references in production code. '
+            . 'TYPO3 v13.4 / DBAL 4 require Doctrine\\DBAL\\ParameterType. See issue #25.' . PHP_EOL
+            . 'Offending lines:' . PHP_EOL . implode(PHP_EOL, $offenders),
+        );
+    }
+
+    public function testEveryProductionFileUsingNamedParameterImportsParameterType(): void
+    {
+        $classesDir = realpath(__DIR__ . '/../../Classes');
+        self::assertNotFalse($classesDir);
+
+        $missing = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($classesDir));
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $contents = (string)file_get_contents($file->getPathname());
+            if (!str_contains($contents, 'createNamedParameter')) {
+                continue;
+            }
+            // If the file uses createNamedParameter with the typed second arg,
+            // it must import Doctrine\DBAL\ParameterType.
+            if (str_contains($contents, 'ParameterType::')
+                && !str_contains($contents, 'use Doctrine\\DBAL\\ParameterType;')
+            ) {
+                $missing[] = str_replace($classesDir . '/', '', $file->getPathname());
+            }
+        }
+
+        self::assertSame(
+            [],
+            $missing,
+            'Files use ParameterType::* but missing the use Doctrine\\DBAL\\ParameterType; import.',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scanForPdoParam(string $dir): array
+    {
+        $offenders = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $relative = str_replace($dir . '/', '', $file->getPathname());
+            $lines = file($file->getPathname()) ?: [];
+            foreach ($lines as $lineNo => $line) {
+                if (str_contains($line, '\\PDO::PARAM') || preg_match('/\bPDO::PARAM/', $line)) {
+                    $offenders[] = sprintf('  %s:%d  %s', $relative, $lineNo + 1, trim($line));
+                }
+            }
+        }
+        return $offenders;
+    }
+}

--- a/Tests/Unit/Service/Quality/LlmQualityCheckerTest.php
+++ b/Tests/Unit/Service/Quality/LlmQualityCheckerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service\Quality;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\LmStudioClient;
+use Kairos\AiEditorialHelper\Service\Quality\LlmQualityChecker;
+use PHPUnit\Framework\TestCase;
+
+final class LlmQualityCheckerTest extends TestCase
+{
+    public function testReturnsEmptyForEmptyContent(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::never())->method('chatJsonSchema');
+
+        $checker = new LlmQualityChecker($client);
+        self::assertSame([], $checker->check('   ', '   '));
+    }
+
+    public function testReturnsNormalizedFlags(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'issues' => [
+                ['kind' => 'tone', 'severity' => 'warning', 'message' => 'Mixing Sie and du.', 'location' => 'Liebe Kunden'],
+                ['kind' => 'clarity', 'severity' => 'info', 'message' => 'Paragraph 2 unclear.'],
+            ],
+        ]);
+
+        $checker = new LlmQualityChecker($client);
+        $flags = $checker->check('Title', '<p>body</p>');
+
+        self::assertCount(2, $flags);
+        self::assertSame('tone', $flags[0]['kind']);
+        self::assertSame('warning', $flags[0]['severity']);
+        self::assertSame('Liebe Kunden', $flags[0]['location']);
+        self::assertSame('clarity', $flags[1]['kind']);
+        self::assertArrayNotHasKey('location', $flags[1]);
+    }
+
+    public function testFiltersOutInvalidKinds(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'issues' => [
+                ['kind' => 'tone', 'severity' => 'warning', 'message' => 'fine'],
+                ['kind' => 'invented', 'severity' => 'warning', 'message' => 'should be dropped'],
+                ['kind' => 'sentence_length', 'severity' => 'warning', 'message' => 'rule-based, not allowed here'],
+            ],
+        ]);
+
+        $checker = new LlmQualityChecker($client);
+        $flags = $checker->check('Title', 'body');
+
+        self::assertCount(1, $flags);
+        self::assertSame('tone', $flags[0]['kind']);
+    }
+
+    public function testFiltersOutInvalidSeverities(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'issues' => [
+                ['kind' => 'tone', 'severity' => 'critical', 'message' => 'invalid severity'],
+                ['kind' => 'tone', 'severity' => 'error', 'message' => 'error not allowed for LLM checks'],
+                ['kind' => 'clarity', 'severity' => 'info', 'message' => 'fine'],
+            ],
+        ]);
+
+        $checker = new LlmQualityChecker($client);
+        $flags = $checker->check('Title', 'body');
+
+        self::assertCount(1, $flags);
+        self::assertSame('clarity', $flags[0]['kind']);
+    }
+
+    public function testCapsAtFiveFlags(): void
+    {
+        $issues = [];
+        for ($i = 0; $i < 10; $i++) {
+            $issues[] = ['kind' => 'clarity', 'severity' => 'info', 'message' => "issue $i"];
+        }
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['issues' => $issues]);
+
+        $checker = new LlmQualityChecker($client);
+        $flags = $checker->check('Title', 'body');
+
+        self::assertCount(5, $flags);
+    }
+
+    public function testTruncatesOverlongMessage(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn([
+            'issues' => [
+                ['kind' => 'tone', 'severity' => 'warning', 'message' => str_repeat('a', 500)],
+            ],
+        ]);
+
+        $checker = new LlmQualityChecker($client);
+        $flags = $checker->check('Title', 'body');
+
+        self::assertCount(1, $flags);
+        self::assertSame(200, mb_strlen($flags[0]['message']));
+    }
+
+    public function testReturnsEmptyOnGarbageShape(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willReturn(['issues' => 'not-an-array']);
+
+        $checker = new LlmQualityChecker($client);
+        self::assertSame([], $checker->check('Title', 'body'));
+    }
+
+    public function testPropagatesUnreachable(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->method('chatJsonSchema')->willThrowException(
+            new LmStudioException('refused', LmStudioException::CODE_UNREACHABLE),
+        );
+
+        $checker = new LlmQualityChecker($client);
+        $this->expectException(LmStudioException::class);
+        $this->expectExceptionCode(LmStudioException::CODE_UNREACHABLE);
+        $checker->check('Title', 'body');
+    }
+
+    public function testIncludesEnumConstraintInSchema(): void
+    {
+        $client = $this->createMock(LmStudioClient::class);
+        $client->expects(self::once())
+            ->method('chatJsonSchema')
+            ->with(
+                self::anything(),
+                self::equalTo('AiEditorialQualityResult'),
+                self::callback(function (array $schema): bool {
+                    $items = $schema['properties']['issues']['items'];
+                    self::assertSame(['tone', 'clarity'], $items['properties']['kind']['enum']);
+                    self::assertSame(['info', 'warning'], $items['properties']['severity']['enum']);
+                    self::assertSame(5, $schema['properties']['issues']['maxItems']);
+                    return true;
+                }),
+                self::anything(),
+            )
+            ->willReturn(['issues' => []]);
+
+        $checker = new LlmQualityChecker($client);
+        $checker->check('Title', '<p>body</p>');
+    }
+}

--- a/Tests/Unit/Service/Quality/RuleBasedQualityCheckerTest.php
+++ b/Tests/Unit/Service/Quality/RuleBasedQualityCheckerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service\Quality;
+
+use Kairos\AiEditorialHelper\Service\Quality\RuleBasedQualityChecker;
+use PHPUnit\Framework\TestCase;
+
+final class RuleBasedQualityCheckerTest extends TestCase
+{
+    public function testReturnsEmptyForEmptyHtml(): void
+    {
+        $checker = new RuleBasedQualityChecker();
+        self::assertSame([], $checker->check(''));
+        self::assertSame([], $checker->check('   '));
+    }
+
+    public function testFlagsLongSentenceAsWarning(): void
+    {
+        $longSentence = 'This sentence has way too many words and keeps going '
+            . 'on and on and on until the editor really should split it into '
+            . 'smaller pieces because nobody likes reading run-on sentences anymore.';
+
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkSentenceLengths($longSentence);
+
+        self::assertCount(1, $flags);
+        self::assertSame('sentence_length', $flags[0]['kind']);
+        self::assertSame('warning', $flags[0]['severity']);
+        self::assertStringContainsString('words', $flags[0]['message']);
+    }
+
+    public function testDoesNotFlagShortSentence(): void
+    {
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkSentenceLengths('A short sentence. Another short one.');
+        self::assertSame([], $flags);
+    }
+
+    public function testFlagsMultipleH1AsError(): void
+    {
+        $html = '<h1>First</h1><p>text</p><h1>Second</h1>';
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkHeadingStructure($html);
+
+        $errors = array_filter($flags, static fn (array $f): bool => $f['severity'] === 'error');
+        self::assertNotEmpty($errors, 'Should report multiple h1 as an error');
+        $first = array_values($errors)[0];
+        self::assertSame('heading_structure', $first['kind']);
+        self::assertStringContainsString('2', $first['message']);
+    }
+
+    public function testFlagsMissingH1AsError(): void
+    {
+        $html = '<h2>Only H2</h2><p>body</p>';
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkHeadingStructure($html);
+
+        $errors = array_filter($flags, static fn (array $f): bool => $f['severity'] === 'error');
+        self::assertNotEmpty($errors);
+        self::assertStringContainsString('h1', strtolower(array_values($errors)[0]['message']));
+    }
+
+    public function testFlagsHeadingHierarchySkip(): void
+    {
+        // h2 → h4 (skipping h3) is a warning
+        $html = '<h1>Title</h1><h2>Section</h2><h4>Sub-sub</h4>';
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkHeadingStructure($html);
+
+        $skipFlags = array_filter(
+            $flags,
+            static fn (array $f): bool => str_contains(strtolower($f['message']), 'skip'),
+        );
+        self::assertCount(1, $skipFlags);
+        self::assertSame('warning', array_values($skipFlags)[0]['severity']);
+    }
+
+    public function testAllowsValidH1H2H3Sequence(): void
+    {
+        $html = '<h1>A</h1><h2>B</h2><h3>C</h3><h2>D</h2><h3>E</h3>';
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkHeadingStructure($html);
+
+        $errors = array_filter($flags, static fn (array $f): bool => $f['severity'] === 'error');
+        $skipFlags = array_filter(
+            $flags,
+            static fn (array $f): bool => str_contains(strtolower($f['message']), 'skip'),
+        );
+        self::assertSame([], array_values($errors));
+        self::assertSame([], array_values($skipFlags));
+    }
+
+    public function testCombinedCheckReturnsAllFlags(): void
+    {
+        $html = '<h2>Section without H1</h2><p>'
+            . str_repeat('word ', 35) . 'This is a long opening sentence that definitely runs past the cap.</p>'
+            . '<h4>Skipping ahead</h4>';
+
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->check($html);
+
+        // Expect at least: missing h1, heading skip, sentence length
+        $kinds = array_map(static fn (array $f): string => $f['kind'], $flags);
+        self::assertContains('heading_structure', $kinds);
+        self::assertContains('sentence_length', $kinds);
+    }
+
+    public function testHandlesGermanContent(): void
+    {
+        $sentence = 'Das ist ein sehr langer Satz der einfach nicht aufhören will und immer '
+            . 'weiter und weiter geht ohne irgendwann mal an einer vernünftigen Stelle zu '
+            . 'enden was die Lesbarkeit deutlich verschlechtert.';
+
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkSentenceLengths($sentence);
+        self::assertCount(1, $flags);
+        self::assertSame('warning', $flags[0]['severity']);
+    }
+
+    public function testStripsHtmlBeforeCountingSentences(): void
+    {
+        // Embedded markup must not inflate word counts.
+        $html = '<p>Short.</p><p>Also <strong>short</strong>.</p>';
+        $checker = new RuleBasedQualityChecker();
+        $flags = $checker->checkSentenceLengths($html);
+        self::assertSame([], $flags);
+    }
+
+    public function testRunsUnderFiftyMillisecondsOnTypicalPage(): void
+    {
+        // Build a typical-sized page: ~5000 chars of body + 5 headings.
+        $body = '<h1>Title</h1>';
+        for ($i = 1; $i <= 4; $i++) {
+            $body .= sprintf('<h2>Section %d</h2>', $i);
+            $body .= '<p>' . str_repeat('Lorem ipsum dolor sit amet. ', 30) . '</p>';
+        }
+
+        $checker = new RuleBasedQualityChecker();
+        $start = microtime(true);
+        $checker->check($body);
+        $elapsedMs = (microtime(true) - $start) * 1000;
+
+        self::assertLessThan(50.0, $elapsedMs, sprintf('Rule-based check took %.1fms (cap 50ms)', $elapsedMs));
+    }
+}

--- a/Tests/Unit/Service/QualityCheckerTest.php
+++ b/Tests/Unit/Service/QualityCheckerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit\Service;
+
+use Kairos\AiEditorialHelper\Exception\LmStudioException;
+use Kairos\AiEditorialHelper\Service\QualityChecker;
+use Kairos\AiEditorialHelper\Service\Quality\LlmQualityChecker;
+use Kairos\AiEditorialHelper\Service\Quality\RuleBasedQualityChecker;
+use PHPUnit\Framework\TestCase;
+
+final class QualityCheckerTest extends TestCase
+{
+    public function testCombinesRuleBasedAndLlmFlags(): void
+    {
+        $rule = $this->createMock(RuleBasedQualityChecker::class);
+        $rule->method('check')->willReturn([
+            ['kind' => 'sentence_length', 'severity' => 'warning', 'message' => 'long sentence'],
+        ]);
+
+        $llm = $this->createMock(LlmQualityChecker::class);
+        $llm->method('check')->willReturn([
+            ['kind' => 'clarity', 'severity' => 'info', 'message' => 'unclear paragraph'],
+        ]);
+
+        $checker = new QualityChecker($rule, $llm);
+        $flags = $checker->check('Title', '<p>body</p>');
+
+        self::assertCount(2, $flags);
+        // warning sorts before info
+        self::assertSame('warning', $flags[0]['severity']);
+        self::assertSame('info', $flags[1]['severity']);
+    }
+
+    public function testSkipsLlmWhenIncludeLlmFalse(): void
+    {
+        $rule = $this->createMock(RuleBasedQualityChecker::class);
+        $rule->method('check')->willReturn([]);
+
+        $llm = $this->createMock(LlmQualityChecker::class);
+        $llm->expects(self::never())->method('check');
+
+        $checker = new QualityChecker($rule, $llm);
+        $flags = $checker->check('Title', '<p>body</p>', false);
+        self::assertSame([], $flags);
+    }
+
+    public function testRecoversWhenLlmThrows(): void
+    {
+        $rule = $this->createMock(RuleBasedQualityChecker::class);
+        $rule->method('check')->willReturn([
+            ['kind' => 'heading_structure', 'severity' => 'error', 'message' => 'no h1'],
+        ]);
+
+        $llm = $this->createMock(LlmQualityChecker::class);
+        $llm->method('check')->willThrowException(
+            new LmStudioException('refused', LmStudioException::CODE_UNREACHABLE),
+        );
+
+        $checker = new QualityChecker($rule, $llm);
+        $flags = $checker->check('Title', '<p>body</p>');
+
+        self::assertGreaterThanOrEqual(2, count($flags));
+        $kinds = array_map(static fn (array $f): string => $f['kind'], $flags);
+        self::assertContains('heading_structure', $kinds);
+        self::assertContains('llm_unavailable', $kinds);
+    }
+
+    public function testSortsByErrorWarningInfoOrder(): void
+    {
+        $rule = $this->createMock(RuleBasedQualityChecker::class);
+        $rule->method('check')->willReturn([
+            ['kind' => 'sentence_length', 'severity' => 'info', 'message' => 'note'],
+            ['kind' => 'sentence_length', 'severity' => 'warning', 'message' => 'long sentence'],
+            ['kind' => 'heading_structure', 'severity' => 'error', 'message' => 'no h1'],
+            ['kind' => 'heading_structure', 'severity' => 'warning', 'message' => 'skipped level'],
+        ]);
+
+        $llm = $this->createMock(LlmQualityChecker::class);
+        $llm->method('check')->willReturn([]);
+
+        $checker = new QualityChecker($rule, $llm);
+        $flags = $checker->check('Title', 'body');
+
+        $severities = array_map(static fn (array $f): string => $f['severity'], $flags);
+        self::assertSame(['error', 'warning', 'warning', 'info'], $severities);
+    }
+
+    public function testAppendsSentinelFlagOnLlmOutage(): void
+    {
+        $rule = $this->createMock(RuleBasedQualityChecker::class);
+        $rule->method('check')->willReturn([]);
+
+        $llm = $this->createMock(LlmQualityChecker::class);
+        $llm->method('check')->willThrowException(
+            new LmStudioException('No model loaded', LmStudioException::CODE_NO_MODEL_LOADED),
+        );
+
+        $checker = new QualityChecker($rule, $llm);
+        $flags = $checker->check('Title', 'body');
+
+        self::assertCount(1, $flags);
+        self::assertSame('llm_unavailable', $flags[0]['kind']);
+        self::assertSame('info', $flags[0]['severity']);
+        self::assertStringContainsString('No model loaded', $flags[0]['message']);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 defined('TYPO3') or die();
 
+use Kairos\AiEditorialHelper\Form\FieldWizard\CheckQualityWizard;
 use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateMetaDescriptionWizard;
 use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateTeaserWizard;
 use Kairos\AiEditorialHelper\Form\FieldWizard\GenerateTranslationStubWizard;
@@ -50,4 +51,10 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140104] = [
     'nodeName' => 'aiEditorialHelperTranslationStub',
     'priority' => 40,
     'class' => GenerateTranslationStubWizard::class,
+];
+
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1714140105] = [
+    'nodeName' => 'aiEditorialHelperCheckQuality',
+    'priority' => 40,
+    'class' => CheckQualityWizard::class,
 ];


### PR DESCRIPTION
Implements [#6](https://github.com/backant-io/typo3-ai-helper/issues/6) — the final feature in the v1 epic. Combines fast pure-PHP rule-based checks with subjective LLM-based checks into a single editor-facing flag list.

## What's included

| Layer | File |
|---|---|
| Rule-based checks | `Classes/Service/Quality/RuleBasedQualityChecker.php` |
| LLM checks | `Classes/Service/Quality/LlmQualityChecker.php` |
| Orchestrator | `Classes/Service/QualityChecker.php` |
| AJAX endpoint | `Classes/Controller/Ajax/QualityCheckerAjaxController.php` |
| Field wizard | `Classes/Form/FieldWizard/CheckQualityWizard.php` (anchored to `pages.title`) |
| TCA wiring | `Configuration/TCA/Overrides/pages.php` |
| Node registry | `ext_localconf.php` |
| ES module | `Resources/Public/JavaScript/quality-checker-wizard.js` |
| AJAX route | `Configuration/Backend/AjaxRoutes.php` |

## Rule-based checks (no LLM, runs instantly)

| Check | Severity | Trigger |
|---|---|---|
| Sentence length > 30 words | warning | Per-sentence; reports word count |
| No `<h1>` on the page | error | Pages with at least one heading |
| Multiple `<h1>` elements | error | Two or more h1 |
| Heading hierarchy skip (e.g. h2 → h4) | warning | Per skip; reports both levels |

Implementation uses DOMDocument + XPath for headings, regex-based sentence splitter (Unicode-aware, handles German punctuation and abbreviations).

## LLM-based checks (subjective)

Single `chatJsonSchema` call returns up to 5 issues:

| Check | Severity |
|---|---|
| Tone inconsistency (Sie/du mixing, register shifts) | warning |
| Clarity (confusing or contradictory paragraphs) | info |

Schema enforces `enum` constraints for `kind` and `severity` so the LLM can't invent new categories. Service post-validates and drops anything that escapes the grammar.

## Resilience: LLM outage doesn't break the audit

If LM Studio is unreachable or no model is loaded, the orchestrator catches the exception and appends a single info-level `llm_unavailable` flag. **Rule-based flags always survive** — the editor still gets the structural audit.

## Tests — 93 / 93 ✓

```
$ docker run --rm -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit -c Tests/UnitTests.xml
…
OK (93 tests, 247 assertions)
```

15 new tests across:

- **`RuleBasedQualityCheckerTest`** (11 tests): empty input, long-sentence flagging, short-sentence pass, multiple h1 error, missing h1 error, heading-skip warning, valid h1/h2/h3 pass, combined check, German content, HTML stripping before counting, **performance regression (<50ms cap)**.
- **`LlmQualityCheckerTest`** (9 tests): empty content no-op, normalised flags, invalid `kind` filtered, invalid `severity` filtered, max-5 cap, message truncation at 200 chars, garbage shape graceful, exception propagation, schema enum constraints asserted.
- **`QualityCheckerTest`** (5 tests): combined output, LLM-skipped path, LLM-throws recovery, severity sort order, sentinel flag on outage.

## Live integration check (qwen/qwen3-14b on LM Studio)

Test page deliberately full of issues:
- 2× `<h1>` (error)
- h2 → h4 skipping h3 (warning)
- 43-word run-on opening sentence (warning)
- mixed Sie/du register (LLM warning if reachable)

Result:

```
[ERROR] heading_structure: Page has 2 <h1> elements. Use exactly one.
[WARNING] heading_structure: Heading hierarchy skips a level: "Skill-Stack" goes from h2 to h4.
[WARNING] sentence_length: Sentence has 43 words (cap 30). Consider splitting it.
[INFO] llm_unavailable: LLM-based checks (tone, clarity) skipped: <connection details>
```

The LLM call timed out in the smoke environment, but the `llm_unavailable` sentinel fired correctly — **the audit still ran end-to-end** with 3 actionable rule-based flags.

## Frontend

The wizard renders an inline panel under the title field with severity-coloured badges (red/orange/blue) and a summary line. No form fields are mutated — this is a read-only audit. Uses the shared `extractAjaxErrorMessage` helper from #19.

## Acceptance-criteria checklist

- [x] `QualityChecker.php` returns array of `{ kind, severity, message, location? }`.
- [x] Rule-based: sentence length > 30 → warning.
- [x] Rule-based: no `<h1>` or multiple `<h1>` → error.
- [x] Rule-based: heading hierarchy skip (h2 → h4) → warning.
- [x] LLM-based: tone inconsistency → warning.
- [x] LLM-based: clarity → info.
- [x] Backend integration: flags rendered as a list with severity icons (badges).
- [x] PHPUnit tests for each rule-based check (no mocking — pure functions).
- [x] Tests for LLM checks use mocked `LmStudioClient`.
- [x] Performance: rule-based checks run < 50ms on a typical page (asserted in tests).
- [x] LLM checks don't block page save (user-triggered via wizard, never auto on save).
- [x] Out of scope: auto-fixing, multilingual quality checks.

This closes the AI Editorial Helper v1 epic — all 6 features merged.

Closes #6.