### PR TITLE
Add GitHub Actions CI for PHPUnit + PHP lint (#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same branch / PR.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: PHP lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+          tools: none
+
+      - name: Lint PHP files
+        run: |
+          set -e
+          find Classes Tests Configuration ext_localconf.php ext_emconf.php \
+            -name '*.php' -print0 \
+          | xargs -0 -n1 php -l
+
+  unit-tests:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # TYPO3 v13.4 requires PHP >= 8.4.
+        php: ["8.4"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: intl, mbstring, json, dom, xml, libxml
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache composer
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache
+            vendor
+          key: composer-${{ matrix.php }}-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            composer-${{ matrix.php }}-
+
+      - name: Install dependencies
+        run: composer install --no-progress --no-interaction --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c Tests/UnitTests.xml --colors=never


### PR DESCRIPTION
Implements [#8](https://github.com/backant-io/typo3-ai-helper/issues/8). Until now the only test runner has been a manual \`docker run --rm php:8.4-cli vendor/bin/phpunit\`. Every cycle's PR description quoted that command — now it runs automatically on every push and PR.

## What this workflow does

`.github/workflows/ci.yml` adds two jobs to **push to main** and **PR to main**:

| Job | Purpose |
|---|---|
| **`lint`** | `find ... -name '*.php' \| xargs -n1 php -l` over `Classes/`, `Tests/`, `Configuration/`, and `ext_*.php`. Catches syntax errors before the more expensive test job runs. |
| **`unit-tests`** | `composer install` (cached on `composer.json` hash) → `vendor/bin/phpunit -c Tests/UnitTests.xml`. Single PHP 8.4 matrix slot — TYPO3 v13.4 requires `>= 8.4` per `composer install`'s platform check. |

`concurrency: cancel-in-progress: true` cancels superseded runs on the same branch/PR (saves runner minutes during force-push churn).

## Security review

No untrusted input flows into any `run:` command. The only `${{ ... }}` interpolations are:

- `github.workflow` / `github.ref` (in concurrency group key) — controlled
- `matrix.php` — controlled (literal `8.4`)
- `hashFiles('composer.json')` (in cache key) — controlled

No `github.event.*` references, no PR title/body/commit-message interpolation.

## Why one PHP version

Earlier cycle 1 learning (`typo3-php-version-in-docker`): `typo3/cms-core ^13.0` (v13.4.x) requires PHP `>= 8.4`. `composer install` on 8.2/8.3 fails the platform check (\`Your Composer dependencies require a PHP version >= 8.4.0\`). Adding 8.5 nightly is a follow-up once 8.5 ships stable.

## Caching strategy

`actions/cache@v4` keys on `composer-${{ matrix.php }}-${{ hashFiles('composer.json') }}` with a per-PHP-version restore-key. This means:
- Same `composer.json` → cache hit, install in seconds.
- Bumped dependency → cache miss but restore-key still picks up most of the vendor tree.

## Verifying it works

After merge, every PR will show `lint` and `unit-tests (PHP 8.4)` checks alongside the existing CodeQL one. Failed tests block merge under default branch protection — currently the `agent-merger` will see the new required-context check.

## Acceptance criteria from #8

- [x] Workflow file at `.github/workflows/ci.yml`.
- [x] Triggers on push and pull_request.
- [x] Runs `composer install` then `vendor/bin/phpunit -c Tests/UnitTests.xml`.
- [x] Matrix on PHP version (currently `[8.4]`; ready to expand).

Closes #8.