### PR TITLE
v1 readiness: bump PHP constraint to ^8.4, refresh README status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
 # TYPO3 AI Editorial Helper
 
 Local-LLM-powered editorial assistant for TYPO3 v13. Generates SEO metadata,
-tags, teasers, slugs, DE↔EN translation stubs, and content quality flags using
-LM Studio on the local machine. **No data leaves the server.**
+categories, teasers, slugs, DE↔EN translation stubs, and content quality flags
+using LM Studio on the local machine. **No data leaves the server.**
 
 Built autonomously by [kairos](https://backant.io).
 
 ## Status
 
+All v1 features shipped:
+
 | Feature | Status |
 |---|---|
-| SEO meta description + page title (#1) | ✅ Shipped — first release |
-| Auto-tag / category suggester (#2) | ⏳ Planned |
-| Teaser / excerpt generator (#3) | ⏳ Planned |
-| URL slug suggester (#4) | ⏳ Planned |
-| DE↔EN translation stub (#5) | ⏳ Planned |
-| Content quality flags (#6) | ⏳ Planned |
+| SEO meta description + page title (#1) | ✅ Shipped |
+| Auto-tag / category suggester (#2) | ✅ Shipped |
+| Teaser / excerpt generator (#3) | ✅ Shipped |
+| URL slug suggester (#4) | ✅ Shipped |
+| DE↔EN translation stub (#5) | ✅ Shipped |
+| Content quality flags (#6) | ✅ Shipped |
 
 ## Runtime requirements
 
 - TYPO3 v13.0+
-- PHP 8.2+
+- **PHP 8.4+** (TYPO3 v13.4 transitively requires PHP 8.4 via `typo3/cms-core`)
 - [LM Studio](https://lmstudio.ai/) running locally with the local server enabled
 - A loaded model — default: `qwen/qwen3-14b` (Qwen 3 14B Instruct).
   Other tested models: `mistralai/magistral-small-2509`.
@@ -48,38 +50,48 @@ In the TYPO3 install tool → **Settings → Extension Configuration → ai_edit
 | `timeout` | `60` | Request timeout in seconds |
 | `apiKey` | `` (empty) | Optional bearer token; LM Studio doesn't need one for local use |
 
-## Usage — SEO meta description + page title
+## Where the wizards appear
 
-1. Edit a page in the TYPO3 backend.
-2. Open the **SEO** tab.
-3. Click **Generate with AI** next to the *Description* or *SEO Title* field.
-4. The extension reads the page's title and tt_content (default language) and
-   asks LM Studio for a meta description (≤160 chars) and SEO title (≤60 chars).
-5. Both values are inserted into the form. Review, edit, save.
+| Wizard | Form field | Page record |
+|---|---|---|
+| Generate meta description + SEO title | `description`, `seo_title` | `pages` (SEO tab) |
+| Suggest categories | `categories` | `pages` |
+| Generate teaser | `abstract` | `pages` (SEO tab) |
+| Suggest slug | `slug` | `pages` (works on unsaved pages too) |
+| Generate translation stub | `bodytext` | `tt_content` (only on localised rows) |
+| Check page quality | `title` | `pages` |
 
-Errors (LM Studio not running, no model loaded) are surfaced as backend
-notifications, not stack traces.
+Errors (LM Studio not running, no model loaded, GET timeouts) are surfaced
+as backend notifications with the LM Studio's own error message — never as
+stack traces or `[object Object]`.
 
 ## Development
 
 ```bash
 composer install
-docker run --rm -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit -c Tests/UnitTests.xml
+vendor/bin/phpunit -c Tests/UnitTests.xml
 ```
 
-The unit tests cover the LM Studio HTTP client, the meta-description service
-(prompt construction, JSON-schema response parsing, length enforcement,
-mid-word cleanup, German content), and the extension settings DTO. They use
-mocked HTTP, so they run without LM Studio.
+If you don't have PHP 8.4 locally:
 
-A live integration check against a real LM Studio instance is documented in
-the PR description for #1.
+```bash
+docker run --rm -v "$PWD":/app -w /app php:8.4-cli sh -c \
+  'composer install --no-progress --no-interaction --prefer-dist \
+   && vendor/bin/phpunit -c Tests/UnitTests.xml'
+```
+
+CI runs `lint` + `unit-tests` jobs on every push and pull request — see
+`.github/workflows/ci.yml`. 117 unit tests cover the LM Studio HTTP client,
+the six editorial services (with prompt + schema assertions, length / format
+enforcement, German-content handling, exception propagation), and the
+FormEngine wizard registration regression for issue #11.
 
 ## Privacy
 
-All inference happens on `localhost:1234`. The extension never makes outbound
-network calls beyond the configured endpoint. No content, no metadata, no
-analytics is sent to any third party.
+All inference happens on the configured `endpoint` (default
+`http://localhost:1234`). The extension never makes outbound network calls
+beyond that endpoint. No content, no metadata, no analytics is sent to any
+third party.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "AI Editorial Helper — local-LLM-powered TYPO3 backend assistant",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "typo3/cms-core": "^13.0",
         "typo3/cms-backend": "^13.0"
     },


### PR DESCRIPTION
Two related polish gaps caught at the end of the v1 epic.

## composer.json: `php` `^8.2` → `^8.4`

The extension declares `"php": "^8.2"` but its transitive dependency `typo3/cms-core ^13.0` (resolves to v13.4.x) requires PHP `>= 8.4`. Composer's `platform_check.php` fails on 8.2/8.3 with the misleading message `Your Composer dependencies require a PHP version >= 8.4.0`.

Bumping our own constraint to `^8.4` surfaces the requirement **before** the resolver runs, so the install error becomes "this package requires PHP ^8.4" — clear and actionable.

This also matches the CI matrix from #23 (PHP 8.4 only) and the cycle 1 `typo3-php-version-in-docker` learning.

## README: status + requirements + wizard reference

| Section | Change |
|---|---|
| Status table | All 6 features → ✅ Shipped (was: only #1). |
| Runtime | "PHP 8.2+" → "PHP 8.4+" with explanation of the cms-core transitive constraint. |
| **New** "Where the wizards appear" | Maps each wizard to its TCA field + record table. Answers the most common "I installed it — where do I click?" question. |
| Errors paragraph | Mentions the #19 fix (no more `[object Object]`). |
| Development | `composer install` + `phpunit`; docker fallback for hosts without PHP 8.4; pointer to the new CI workflow. |
| Privacy | "configured endpoint" instead of hardcoded `localhost:1234` (the endpoint is configurable per #1). |

## Why now

Once #22 (quality flags) and #23 (CI) land, the project ships v1.0. A v1.0 release with composer.json claiming "^8.2" while actually requiring "^8.4" produces a poor first-install experience. This PR closes the gap before tagging.

## Tests

No PHP code changes — only metadata + documentation. The 117 unit tests on the underlying code passed in the last cycle and still pass. CI on this PR will confirm via #23 once #23 lands; until then, manual run:

```
docker run --rm -v "$PWD":/app -w /app php:8.4-cli sh -c \\
  'composer install --no-progress --no-interaction --prefer-dist \\
   && vendor/bin/phpunit -c Tests/UnitTests.xml'
```