### PR TITLE
Fix #25: replace \PDO::PARAM_INT with Doctrine\DBAL\ParameterType (DBAL 4)

### DIFF
--- a/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/CategorySuggesterAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\CategorySuggesterService;
 use Psr\Http\Message\ResponseInterface;
@@ -70,8 +71,8 @@ final class CategorySuggesterAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->setMaxResults(20)

--- a/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
+++ b/Classes/Controller/Ajax/MetaDescriptionAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\MetaDescriptionService;
 use Psr\Http\Message\ResponseInterface;
@@ -71,8 +72,8 @@ final class MetaDescriptionAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->executeQuery()

--- a/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
+++ b/Classes/Controller/Ajax/SlugSuggesterAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\SlugSuggesterService;
 use Psr\Http\Message\ResponseInterface;
@@ -75,8 +76,8 @@ final class SlugSuggesterAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->setMaxResults(20)

--- a/Classes/Controller/Ajax/TeaserAjaxController.php
+++ b/Classes/Controller/Ajax/TeaserAjaxController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Controller\Ajax;
 
+use Doctrine\DBAL\ParameterType;
 use Kairos\AiEditorialHelper\Exception\LmStudioException;
 use Kairos\AiEditorialHelper\Service\TeaserService;
 use Psr\Http\Message\ResponseInterface;
@@ -63,8 +64,8 @@ final class TeaserAjaxController
             ->select('header', 'subheader', 'bodytext')
             ->from('tt_content')
             ->where(
-                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, \PDO::PARAM_INT)),
-                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('pid', $qb->createNamedParameter($pageUid, ParameterType::INTEGER)),
+                $qb->expr()->eq('sys_language_uid', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->setMaxResults(20)

--- a/Classes/Service/CategoryRepository.php
+++ b/Classes/Service/CategoryRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kairos\AiEditorialHelper\Service;
 
+use Doctrine\DBAL\ParameterType;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
@@ -32,7 +33,7 @@ class CategoryRepository
             ->select('uid', 'title', 'description')
             ->from(self::TABLE)
             ->where(
-                $qb->expr()->eq('parent', $qb->createNamedParameter(0, \PDO::PARAM_INT)),
+                $qb->expr()->eq('parent', $qb->createNamedParameter(0, ParameterType::INTEGER)),
             )
             ->orderBy('sorting', 'ASC')
             ->addOrderBy('title', 'ASC')

--- a/Tests/Unit/DbalParameterTypeRegressionTest.php
+++ b/Tests/Unit/DbalParameterTypeRegressionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kairos\AiEditorialHelper\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for issue #25.
+ *
+ * TYPO3 v13.4 ships Doctrine DBAL 4. DBAL 4 dropped support for the legacy
+ * integer-form constants (\PDO::PARAM_INT === 1) on
+ * QueryBuilder::createNamedParameter() — the second arg must now be one of:
+ *   - Doctrine\DBAL\ParameterType
+ *   - Doctrine\DBAL\Types\Type
+ *   - Doctrine\DBAL\ArrayParameterType
+ *   - string
+ *
+ * Passing \PDO::PARAM_INT raises TypeError at runtime. This was a demo-blocker
+ * caught only on a real v13.4 install — PHPUnit tests with mocked QueryBuilder
+ * never executed the strict signature.
+ *
+ * This test is a static-analysis-style guard: it greps the production source
+ * tree for any `\PDO::PARAM_*` reference and fails the suite if any is found.
+ * Cheaper than a full functional test against typo3/testing-framework, and
+ * locks in the fix as long as nobody disables the test.
+ */
+final class DbalParameterTypeRegressionTest extends TestCase
+{
+    public function testNoLegacyPdoParamConstantsInProductionCode(): void
+    {
+        $classesDir = realpath(__DIR__ . '/../../Classes');
+        self::assertNotFalse($classesDir, 'Classes/ directory must exist');
+
+        $offenders = $this->scanForPdoParam($classesDir);
+
+        self::assertSame(
+            [],
+            $offenders,
+            'Found legacy \\PDO::PARAM_* references in production code. '
+            . 'TYPO3 v13.4 / DBAL 4 require Doctrine\\DBAL\\ParameterType. See issue #25.' . PHP_EOL
+            . 'Offending lines:' . PHP_EOL . implode(PHP_EOL, $offenders),
+        );
+    }
+
+    public function testEveryProductionFileUsingNamedParameterImportsParameterType(): void
+    {
+        $classesDir = realpath(__DIR__ . '/../../Classes');
+        self::assertNotFalse($classesDir);
+
+        $missing = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($classesDir));
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $contents = (string)file_get_contents($file->getPathname());
+            if (!str_contains($contents, 'createNamedParameter')) {
+                continue;
+            }
+            // If the file uses createNamedParameter with the typed second arg,
+            // it must import Doctrine\DBAL\ParameterType.
+            if (str_contains($contents, 'ParameterType::')
+                && !str_contains($contents, 'use Doctrine\\DBAL\\ParameterType;')
+            ) {
+                $missing[] = str_replace($classesDir . '/', '', $file->getPathname());
+            }
+        }
+
+        self::assertSame(
+            [],
+            $missing,
+            'Files use ParameterType::* but missing the use Doctrine\\DBAL\\ParameterType; import.',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scanForPdoParam(string $dir): array
+    {
+        $offenders = [];
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+            $relative = str_replace($dir . '/', '', $file->getPathname());
+            $lines = file($file->getPathname()) ?: [];
+            foreach ($lines as $lineNo => $line) {
+                if (str_contains($line, '\\PDO::PARAM') || preg_match('/\bPDO::PARAM/', $line)) {
+                    $offenders[] = sprintf('  %s:%d  %s', $relative, $lineNo + 1, trim($line));
+                }
+            }
+        }
+        return $offenders;
+    }
+}


### PR DESCRIPTION
Fixes [#25](https://github.com/backant-io/typo3-ai-helper/issues/25) — demo-blocker bug where every wizard's `loadPageBody` crashed on real TYPO3 v13.4 installs.

## Root cause

TYPO3 v13.4 ships Doctrine DBAL 4. DBAL 4 dropped support for the legacy integer-form type constants on `QueryBuilder::createNamedParameter()`:

```
TypeError: QueryBuilder::createNamedParameter():
  Argument #2 ($type) must be of type
  Doctrine\DBAL\ParameterType|...|string,
  int given
```

`\PDO::PARAM_INT` is the integer constant `1`, which DBAL 4 rejects. The mocked `QueryBuilder` in our PHPUnit tests skipped this strict-signature check, so the bug only surfaced on a live v13.4 install.

## Fix

9 occurrences across 5 files replaced with `Doctrine\DBAL\ParameterType::INTEGER`:

| File | Sites |
|---|---|
| `Classes/Controller/Ajax/MetaDescriptionAjaxController.php` | 2 |
| `Classes/Controller/Ajax/CategorySuggesterAjaxController.php` | 2 |
| `Classes/Controller/Ajax/SlugSuggesterAjaxController.php` | 2 |
| `Classes/Controller/Ajax/TeaserAjaxController.php` | 2 |
| `Classes/Service/CategoryRepository.php` | 1 |

Each file gained `use Doctrine\DBAL\ParameterType;`.

```
$ git grep -n 'PDO::PARAM' Classes/
(no output)
```

## Regression test

`Tests/Unit/DbalParameterTypeRegressionTest.php` is a static-analysis-style guard, modelled after the `ExtLocalconfTest` pattern from #11. Two assertions:

1. **No `\PDO::PARAM_*` references anywhere under `Classes/`** — if a future PR re-introduces the legacy constant, the suite fails with a pointer to #25 and a list of offending `file:line`.
2. **Every file using `ParameterType::*` imports `Doctrine\DBAL\ParameterType`** — catches missing-use-statement bugs that PHPUnit alone wouldn't surface.

Cheaper than a full `typo3/testing-framework` functional test (issue #27 will add those later) and locks in the fix at minimal cost.

## Tests — 94 / 94 ✓

```
$ docker run --rm -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit -c Tests/UnitTests.xml
…
OK (94 tests, 315 assertions)
```

92 prior + 2 new regression tests.

## Note for parallel PRs

PR #22 (quality flags, awaiting auto-merge) introduces a 6th controller (`QualityCheckerAjaxController`) with the same `\PDO::PARAM_INT` pattern. After this PR lands, that one will fail the new regression test on rebase — a follow-up commit on PR #22's branch (or whichever rebased version lands) will need the same one-line fix.

## Acceptance from #25

- [x] No `\PDO::PARAM_*` references remain in `Classes/` (grep returns zero hits — asserted by regression test).
- [x] Existing PHPUnit tests pass.
- [x] Regression test added (chose static-analysis-style over full functional test, per #25's "optional" framing).
- [ ] Manual: click each wizard button on DDEV TYPO3 v13.4 — for the human reviewer.

Closes #25.